### PR TITLE
Add batch complete features via label

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -81,8 +81,10 @@ public class CompleteCommand extends Command {
      * representing all completed tasks.
      * If a {@code CommandException} is thrown during the execution, all preceding completed tasks
      * will be rollbacked.
+     *
      * @param modelToUpdate model to update
      * @return {@code String} representation of all the completed {@code Task}
+     *
      * @throws CommandException if there are no completable task that fulfills {@code taskPredicate}
      */
     private String completeAllTasksReturnStringOfTasks(Model modelToUpdate)
@@ -115,7 +117,9 @@ public class CompleteCommand extends Command {
     /**
      * Completes the task supplied, updates the model without committing the model and returns
      * the {@code String} representation of the {@code Task}.
+     *
      * @return {@code String} representing the completed {@code Task}
+     *
      * @throws CommandException if the given {@code taskToComplete} is already completed
      */
     private String completeOneTaskReturnStringOfTask(Task taskToComplete, Model modelToUpdate)
@@ -134,8 +138,10 @@ public class CompleteCommand extends Command {
     /**
      * Completes a task as identified by its index, updates the model without committing and returns
      * the {@code String} representation of the {@code Task}.
+     *
      * @param lastShownList {@code List} containing all the valid tasks to complete
      * @return {@code String} representing the completed {@code Task}
+     *
      * @throws CommandException if Index is invalid or task is already completed
      */
     private String completeOneTaskReturnStringOfTask(Index targetIndex,
@@ -159,10 +165,7 @@ public class CompleteCommand extends Command {
     }
 
     /**
-     * Generates a set of task that can be completed which also satisfies the supplied predicate.
-     * @param pred
-     * @param model
-     * @return
+     * Generates a set of tasks that can be completed which also satisfies the supplied predicate.
      */
     private Set<Task> generateSetOfCompletableTasks(Predicate<Task> pred, Model model) {
         Set<Task> setOfTasks = new HashSet<>();

--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -20,23 +22,89 @@ public class CompleteCommand extends Command {
 
     public static final String COMMAND_WORD = "complete";
     public static final String MESSAGE_SUCCESS = "Good job! You have completed your task:\n%1$s";
+    public static final String MESSAGE_NO_TASK_IDENTIFIED_BY_LABEL = "There are no tasks to "
+        + "be found via your given label";
     public static final String MESSAGE_ALREADY_COMPLETED = "This task has already been completed";
+    //TODO: Change prompt to indicate usage with labels
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Completes the task identified by the targetIndex number used in the displayed task list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+        + ": Completes the task identified by the Index number used in the displayed task list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
 
-    private final Index targetIndex;
+    private final Set<Index> targetIndexes;
 
     public CompleteCommand(Index targetIndex) {
-        requireNonNull(targetIndex);
-        this.targetIndex = targetIndex;
+        // The below expression (Set.of(...)) functions as a requireNonNull,
+        // a NullPointerException will be thrown if targetIndex is null,
+        // thus requireNonNull is omitted.
+        this(Set.of(targetIndex));
+    }
+
+    public CompleteCommand(Set<Index> setOfIndexes) {
+        requireNonNull(setOfIndexes);
+        this.targetIndexes = setOfIndexes;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
         List<Task> lastShownList = model.getFilteredTaskList();
+
+        String completedTasksOutput = completeAllTasksReturnStringOfTasks(lastShownList, model);
+
+        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        model.commitTaskManager();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, completedTasksOutput));
+    }
+
+    /**
+     * Completes all tasks in a set, and returns a String representing all completed tasks.
+     * If a {@code CommandException} is thrown during the execution, all preceding completed tasks
+     * will be rollbacked.
+     * @param lastShownList {@code List} containing all the valid tasks to complete
+     * @param modelToUpdate model to update
+     * @return {@code String} representation of all the completed {@code Tasks}
+     * @throws CommandException
+     */
+    private String completeAllTasksReturnStringOfTasks(List<Task> lastShownList,
+                                                       Model modelToUpdate)
+        throws CommandException {
+
+        if (this.targetIndexes.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_TASK_IDENTIFIED_BY_LABEL);
+        }
+
+        // Iterates through the valid set of indexes and stores results in completedTasks.
+        Iterator<Index> indexIterator = this.targetIndexes.iterator();
+        String completedTasks = "";
+        try {
+            while (indexIterator.hasNext()) {
+                Index indexOfTaskToComplete = indexIterator.next();
+                completedTasks += completeOneTaskReturnStringOfTask(
+                    indexOfTaskToComplete,
+                    lastShownList,
+                    modelToUpdate) + "\n";
+            }
+        } catch (CommandException ce) {
+            modelToUpdate.rollbackTaskManager();
+            throw ce;
+        }
+        return completedTasks.trim();
+    }
+
+    /**
+     * Completes a task as identified by its index, updates the model wihtout committing and returns
+     * the {@code String} representation of the {@code Task}.
+     * @param targetIndex {@code Index} of task to update
+     * @param lastShownList {@code List} containing all the valid tasks to complete
+     * @param modelToUpdate model to update
+     * @return {@code String} representing the completed {@code Task}
+     * @throws CommandException
+     */
+    private String completeOneTaskReturnStringOfTask(Index targetIndex,
+                                                     List<Task> lastShownList,
+                                                     Model modelToUpdate)
+        throws CommandException {
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
@@ -49,26 +117,25 @@ public class CompleteCommand extends Command {
             throw new CommandException(MESSAGE_ALREADY_COMPLETED);
         }
 
-        model.updateTask(taskToComplete, completedTask);
-        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
-        model.commitTaskManager();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, completedTask));
+        modelToUpdate.updateTask(taskToComplete, completedTask);
+        return completedTask.toString();
     }
 
     /**
      * Returns a {@code Task} with it's status set to {@code Status.COMPLETED}.
+     *
      * @param toComplete An immutable task passed to have its attributes copied
      * @return A new immutable task similar to toComplete but status is set to
-     *         {@code Status.COMPLETED}
+     * {@code Status.COMPLETED}
      */
     public Task createCompletedTask(Task toComplete) {
         return new Task(
-                toComplete.getName(),
-                toComplete.getDueDate(),
-                toComplete.getPriorityValue(),
-                toComplete.getDescription(),
-                toComplete.getLabels(),
-                Status.COMPLETED);
+            toComplete.getName(),
+            toComplete.getDueDate(),
+            toComplete.getPriorityValue(),
+            toComplete.getDescription(),
+            toComplete.getLabels(),
+            Status.COMPLETED);
     }
 
     @Override
@@ -76,7 +143,7 @@ public class CompleteCommand extends Command {
         if (obj == null) {
             return false;
         } else if (obj instanceof CompleteCommand) {
-            return targetIndex.equals(((CompleteCommand) obj).targetIndex);
+            return targetIndexes.equals(((CompleteCommand) obj).targetIndexes);
         } else {
             // superclass's implementation might pass,
             // although in this instance it's a == relationship.

--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -34,16 +34,10 @@ public class CompleteCommand extends Command {
     private final Set<Index> targetIndexes;
 
     public CompleteCommand(Index targetIndex) {
-        // The below expression (Set.of(...)) functions as a requireNonNull,
-        // a NullPointerException will be thrown if targetIndex is null,
-        // thus requireNonNull is omitted.
-        this(Set.of(targetIndex));
+        requireNonNull(targetIndex);
+        this.targetIndexes = (Set.of(targetIndex));
     }
 
-    public CompleteCommand(Set<Index> setOfIndexes) {
-        requireNonNull(setOfIndexes);
-        this.targetIndexes = setOfIndexes;
-    }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -168,12 +169,17 @@ public class CompleteCommand extends Command {
      * Generates a set of tasks that can be completed which also satisfies the supplied predicate.
      */
     private Set<Task> generateSetOfCompletableTasks(Predicate<Task> pred, Model model) {
+        // Preserve a shallow copy of original list of task to restore later on
+        List<Task> originalTasks = new ArrayList<>(model.getFilteredTaskList());
+
+        // Add all of the completable tasks to setOfTasks
         Set<Task> setOfTasks = new HashSet<>();
         model.updateFilteredTaskList(pred.and(task -> !task.isCompleted()));
         List<Task> filteredList = model.getFilteredTaskList();
-
-        // Add all of the completable tasks to setOFTasks
         setOfTasks.addAll(filteredList);
+
+        // Restore filteredTaskList to it's original view
+        model.updateFilteredTaskList(task -> originalTasks.contains(task));
 
         return setOfTasks;
     }

--- a/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
@@ -1,10 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.CompleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.task.LabelMatchesKeywordPredicate;
 
 /**
  * Parses input arguments and creates a new CompleteCommand object
@@ -12,19 +15,59 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class CompleteCommandParser implements Parser<CompleteCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the CompleteCommand
-     * and returns an CompleteCommand object for execution.
-     *
+     * Parses the given {@code args} and decides if {@code args} contains {@code Index} symbols
+     * or {@code Label} symbols, then returning an appropriate CompleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public CompleteCommand parse(String args) throws ParseException {
+        // Sanitize arguments so that boolean checks don't trip on whitespaces
+        String sanitizedArgs = args.trim();
+
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(sanitizedArgs, PREFIX_LABEL);
+        boolean isLabelSymbol = argMultimap.getValue(PREFIX_LABEL).isPresent();
+        boolean isIndexSymbol = StringUtil.isNonZeroUnsignedInteger(sanitizedArgs);
+
+        // CompleteCommand does not support label and index based symbols in the same command
+        if (isLabelSymbol && !isIndexSymbol) {
+            return parseLabel(argMultimap);
+        } else if (isIndexSymbol && !isLabelSymbol) {
+            return parseIndex(sanitizedArgs);
+        } else {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CompleteCommand.MESSAGE_USAGE));
+        }
+    }
+
+
+    /**
+     * Parses the given {@code String} of arguments in the context of a single {@code Index}
+     * based CompleteCommand and returns an CompleteCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private CompleteCommand parseIndex(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new CompleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CompleteCommand.MESSAGE_USAGE), pe);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CompleteCommand.MESSAGE_USAGE), pe);
         }
+    }
+
+
+    /**
+     * Precondition: argMultiMaps contains args mapped to PREFIX_LABEL
+     * Parses the given {@code String} of arguments in the context of the batch-based {@code Task<Predicate>}
+     * consuming CompleteCommand and returns an CompleteCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private CompleteCommand parseLabel(ArgumentMultimap argMultiMap) {
+        String labelArg = argMultiMap.getValue(PREFIX_LABEL).get();
+
+        return new CompleteCommand(new LabelMatchesKeywordPredicate(labelArg));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
@@ -48,6 +48,10 @@ public class CompleteCommandParser implements Parser<CompleteCommand> {
         }
     }
 
+    /**
+     * Checks if the list of tokens only has a single occurence of an index symbol
+     * Returns true if yes, else false.
+     */
     private boolean isSingleIndexSymbol(List<String> tokens) {
         int numberOfMatches = 0;
         for (String token : tokens) {

--- a/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
@@ -3,6 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
 
+import java.util.Arrays;
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.CompleteCommand;
@@ -17,28 +20,43 @@ public class CompleteCommandParser implements Parser<CompleteCommand> {
     /**
      * Parses the given {@code args} and decides if {@code args} contains {@code Index} symbols
      * or {@code Label} symbols, then returning an appropriate CompleteCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public CompleteCommand parse(String args) throws ParseException {
-        // Sanitize arguments so that boolean checks don't trip on whitespaces
-        String sanitizedArgs = args.trim();
-
+        // Split up symbols into tokens delimited by whitespace
+        List<String> tokens = Arrays.asList(args.split("\\s+"));
+        // Take note,
+        // ArgumentTokenizer requires one whitespace before the argument otherwise it would fail in detecting prefixes
+        // Spent some time debugging this when args.trim() was used to remove whitespaces
         ArgumentMultimap argMultimap =
-            ArgumentTokenizer.tokenize(sanitizedArgs, PREFIX_LABEL);
+            ArgumentTokenizer.tokenize(args, PREFIX_LABEL);
+
         boolean isLabelSymbol = argMultimap.getValue(PREFIX_LABEL).isPresent();
-        boolean isIndexSymbol = StringUtil.isNonZeroUnsignedInteger(sanitizedArgs);
+        boolean isSingleIndexSymbol = isSingleIndexSymbol(tokens);
+
 
         // CompleteCommand does not support label and index based symbols in the same command
-        if (isLabelSymbol && !isIndexSymbol) {
+        if (isLabelSymbol && !isSingleIndexSymbol) {
             return parseLabel(argMultimap);
-        } else if (isIndexSymbol && !isLabelSymbol) {
-            return parseIndex(sanitizedArgs);
+        } else if (isSingleIndexSymbol && !isLabelSymbol) {
+            // No need to filter for a single token since it has been guaranteed to only hold one Index symbol
+            return parseIndex(args);
         } else {
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, CompleteCommand.MESSAGE_USAGE));
         }
     }
 
+    private boolean isSingleIndexSymbol(List<String> tokens) {
+        int numberOfMatches = 0;
+        for (String token : tokens) {
+            if (StringUtil.isNonZeroUnsignedInteger(token)) {
+                numberOfMatches++;
+            }
+        }
+        return numberOfMatches == 1;
+    }
 
     /**
      * Parses the given {@code String} of arguments in the context of a single {@code Index}
@@ -59,6 +77,7 @@ public class CompleteCommandParser implements Parser<CompleteCommand> {
 
     /**
      * Precondition: argMultiMaps contains args mapped to PREFIX_LABEL
+     *
      * Parses the given {@code String} of arguments in the context of the batch-based {@code Task<Predicate>}
      * consuming CompleteCommand and returns an CompleteCommand object for execution.
      *

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,10 @@ public interface Model {
      * Saves the current task manager state for undo/redo.
      */
     void commitTaskManager();
+
+    /**
+     * Removes all uncommited changes and rollbacks to state pointed by
+     * current state pointer.
+     */
+    void rollbackTaskManager();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -132,6 +132,11 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public void rollbackTaskManager() {
+        versionedTaskManager.rollback();
+        indicateTaskManagerChanged();
+    }
+    @Override
     public boolean equals(Object obj) {
         // short circuit if same object
         if (obj == this) {

--- a/src/main/java/seedu/address/model/VersionedTaskManager.java
+++ b/src/main/java/seedu/address/model/VersionedTaskManager.java
@@ -29,6 +29,16 @@ public class VersionedTaskManager extends TaskManager {
         currentStatePointer++;
     }
 
+    /**
+     * Precondition: VersionedTaskManager is initialised with a non-empty taskManagerStateList
+     * Reverts current data to VersionedTaskManager's latest commit.
+     */
+    public void rollback() {
+        int latestCommit = taskManagerStateList.size() - 1;
+        resetData(taskManagerStateList.get(latestCommit));
+        currentStatePointer = latestCommit;
+    }
+
     private void removeStatesAfterCurrentPointer() {
         taskManagerStateList.subList(currentStatePointer + 1, taskManagerStateList.size()).clear();
     }

--- a/src/main/java/seedu/address/model/task/LabelMatchesKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/task/LabelMatchesKeywordPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.task;
+
+import java.util.function.Predicate;
+
+import seedu.address.model.tag.Label;
+
+// TODO: Refactor code and rewrite class to look for labels
+/**
+ * Tests that a {@code Task}'s {@code Name} matches any of the keywords given.
+ */
+public class LabelMatchesKeywordPredicate implements Predicate<Task> {
+    private final Label keyLabel;
+
+    public LabelMatchesKeywordPredicate(String keyword) {
+        Label keyLabel = new Label(keyword);
+        this.keyLabel = keyLabel;
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return task.getLabels().contains(keyLabel);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof LabelMatchesKeywordPredicate // instanceof handles nulls
+                && keyLabel.equals(((LabelMatchesKeywordPredicate) other).keyLabel)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -163,6 +163,11 @@ public class AddCommandTest {
         public void commitTaskManager() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void rollbackTaskManager() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_VALUE;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
@@ -93,6 +94,34 @@ public class CommandTestUtil {
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the set of result message tokens matches {@code expectedTokens} <br>
+     * - the {@code actualModel} matches {@code expectedModel} <br>
+     * - the {@code actualCommandHistory} remains unchanged.
+     *
+     * Note that the order of result message separated by a new line need not matter.
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualCommandHistory,
+                                            Set<String> expectedTokens, Model expectedModel) {
+        CommandHistory expectedCommandHistory = new CommandHistory(actualCommandHistory);
+        try {
+            CommandResult result = command.execute(actualModel, actualCommandHistory);
+            assertEquals(expectedTokens, feedbackMessageTokenizer(result.feedbackToUser));
+            assertEquals(expectedModel, actualModel);
+            assertEquals(expectedCommandHistory, actualCommandHistory);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+    }
+
+    /**
+     * Returns a set of String split by a newline.
+     */
+    public static Set<String> feedbackMessageTokenizer(String feedbackMessage) {
+        return Set.of(feedbackMessage.split("\\R+"));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -121,7 +121,7 @@ public class CompleteCommandTest {
         expectedModel.undoTaskManager();
         assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
-        // redo -> same first task deleted again
+        // redo -> same first task completed again
         expectedModel.redoTaskManager();
         assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -166,7 +166,7 @@ public class CompleteCommandTest {
         assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         assertNotEquals(taskToComplete, model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased()));
-        // redo -> deletes same second task in unfiltered task list
+        // redo -> completes same second task in unfiltered task list
         expectedModel.redoTaskManager();
         assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -200,8 +200,12 @@ public class CompleteCommandTest {
 
     /**
      * Helper method for more complicated batch completion on {@code Label} match.
+     *
+     * @return an Expected-Model Expected-String pair
      */
-    private Pair<Model, String> produceExpectedModelOnLabelKeywordMatch(String labelString, Model model) {
+    private Pair<Model, String> produceExpectedModelExpectedMessagePairOnLabelKeywordMatch(
+        String labelString,
+        Model model) {
 
         ModelManager expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
         StringBuilder expectedMessage = new StringBuilder();

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -215,7 +215,7 @@ public class CompleteCommandTest {
         expectedModel
             .getFilteredTaskList()
             .stream()
-            .map(task -> new Pair<Task, Task>(task, simpleCompleteTask(task)))
+            .map(task -> new Pair<>(task, simpleCompleteTask(task)))
             // filters for label match and completable tasks
             .filter(pairOfTasks -> {
                 Task taskToComplete = pairOfTasks.getKey();
@@ -235,7 +235,7 @@ public class CompleteCommandTest {
         expectedModel.commitTaskManager();
         String finalMessage = expectedMessage.toString().trim();
 
-        return new Pair<Model, String>(expectedModel, finalMessage);
+        return new Pair<>(expectedModel, finalMessage);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -106,6 +106,15 @@ public class CompleteCommandTest {
     }
 
     @Test
+    public void execute_invalidLabel_throwsCommandException() {
+        LabelMatchesKeywordPredicate keywordNoOccurence = new LabelMatchesKeywordPredicate("adiouweaphfewoip");
+        CompleteCommand completeCommand = new CompleteCommand(keywordNoOccurence);
+
+        assertCommandFailure(completeCommand, model, commandHistory,
+            CompleteCommand.MESSAGE_NO_COMPLETABLE_TASK_IDENTIFIED_BY_LABEL);
+    }
+
+    @Test
     public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
         Task taskToComplete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
         CompleteCommand completeCommand = new CompleteCommand(INDEX_FIRST_TASK);

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -54,20 +54,6 @@ public class CompleteCommandTest {
     }
 
     @Test
-    public void execute_validLabel_success() {
-        CompleteCommand completeCommand = new CompleteCommand(FRIENDS_PREDICATE);
-
-        Pair<Model, Set<String>> modelStringPair = produceExpectedModelExpectedMessagePairOnLabelKeywordMatch(
-            "friends",
-            model);
-
-        Model expectedModel = modelStringPair.getKey();
-        Set<String> expectedTokens = modelStringPair.getValue();
-
-        assertCommandSuccess(completeCommand, model, commandHistory, expectedTokens, expectedModel);
-    }
-
-    @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
         CompleteCommand completeCommand = new CompleteCommand(outOfBoundIndex);
@@ -103,6 +89,20 @@ public class CompleteCommandTest {
         CompleteCommand completeCommand = new CompleteCommand(outOfBoundIndex);
 
         assertCommandFailure(completeCommand, model, commandHistory, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validLabel_success() {
+        CompleteCommand completeCommand = new CompleteCommand(FRIENDS_PREDICATE);
+
+        Pair<Model, Set<String>> modelStringPair = produceExpectedModelExpectedMessagePairOnLabelKeywordMatch(
+            "friends",
+            model);
+
+        Model expectedModel = modelStringPair.getKey();
+        Set<String> expectedTokens = modelStringPair.getValue();
+
+        assertCommandSuccess(completeCommand, model, commandHistory, expectedTokens, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -210,11 +210,20 @@ public class CompleteCommandTest {
         ModelManager expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
         StringBuilder expectedMessage = new StringBuilder();
 
+        // Updates the model with completable tasks that fulfils the predicate completed and append
+        // each of their String representation to expectedMessage
         expectedModel
             .getFilteredTaskList()
             .stream()
             .map(task -> new Pair<Task, Task>(task, simpleCompleteTask(task)))
-            .filter(pairOfTasks -> pairOfTasks.getKey().getLabels().contains(new Label((labelString))))
+            // filters for label match and completable tasks
+            .filter(pairOfTasks -> {
+                Task taskToComplete = pairOfTasks.getKey();
+                return taskToComplete
+                    .getLabels()
+                    .contains(new Label((labelString)))
+                    && !taskToComplete.isCompleted();
+            })
             .forEach(pairOfTasks -> {
                 Task taskToComplete = pairOfTasks.getKey();
                 Task completedTask = pairOfTasks.getValue();

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -54,7 +54,7 @@ public class CompleteCommandTest {
     }
 
     @Test
-    public void execute_validLabelUnfilteredList_success() {
+    public void execute_validLabel_success() {
         CompleteCommand completeCommand = new CompleteCommand(FRIENDS_PREDICATE);
 
         Pair<Model, Set<String>> modelStringPair = produceExpectedModelExpectedMessagePairOnLabelKeywordMatch(

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -95,11 +95,12 @@ public class CompleteCommandTest {
     public void execute_validLabel_success() {
         CompleteCommand completeCommand = new CompleteCommand(FRIENDS_PREDICATE);
 
+        Model expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
         Pair<Model, Set<String>> modelStringPair = produceExpectedModelExpectedMessagePairOnLabelKeywordMatch(
             "friends",
-            model);
+            expectedModel);
 
-        Model expectedModel = modelStringPair.getKey();
+        expectedModel = modelStringPair.getKey();
         Set<String> expectedTokens = modelStringPair.getValue();
 
         assertCommandSuccess(completeCommand, model, commandHistory, expectedTokens, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -13,12 +13,14 @@ import static seedu.address.testutil.TypicalTasks.getTypicalTaskManager;
 
 import org.junit.Test;
 
+import javafx.util.Pair;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.Label;
 import seedu.address.model.task.Status;
 import seedu.address.model.task.Task;
 
@@ -187,13 +189,40 @@ public class CompleteCommandTest {
      */
     private Task simpleCompleteTask(Task taskToComplete) {
         return new Task(// returns a completed task.
-                taskToComplete.getName(),
-                taskToComplete.getDueDate(),
-                taskToComplete.getPriorityValue(),
-                taskToComplete.getDescription(),
-                taskToComplete.getLabels(),
-                Status.COMPLETED
+            taskToComplete.getName(),
+            taskToComplete.getDueDate(),
+            taskToComplete.getPriorityValue(),
+            taskToComplete.getDescription(),
+            taskToComplete.getLabels(),
+            Status.COMPLETED
         );
+    }
+
+    /**
+     * Helper method for more complicated batch completion on {@code Label} match.
+     */
+    private Pair<Model, String> produceExpectedModelOnLabelKeywordMatch(String labelString, Model model) {
+
+        ModelManager expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
+        StringBuilder expectedMessage = new StringBuilder();
+
+        expectedModel
+            .getFilteredTaskList()
+            .stream()
+            .map(task -> new Pair<Task, Task>(task, simpleCompleteTask(task)))
+            .filter(pairOfTasks -> pairOfTasks.getKey().getLabels().contains(new Label((labelString))))
+            .forEach(pairOfTasks -> {
+                Task taskToComplete = pairOfTasks.getKey();
+                Task completedTask = pairOfTasks.getValue();
+                expectedModel.updateTask(taskToComplete, completedTask);
+                expectedMessage.append(completedTask.toString() + "\n");
+            });
+
+
+        expectedModel.commitTaskManager();
+        String finalMessage = expectedMessage.toString().trim();
+
+        return new Pair<Model, String>(expectedModel, finalMessage);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
@@ -19,8 +19,8 @@ import seedu.address.model.task.LabelMatchesKeywordPredicate;
  */
 public class CompleteCommandParserTest {
 
+    private static final LabelMatchesKeywordPredicate LABEL_FRIENDS = new LabelMatchesKeywordPredicate("friends");
     private CompleteCommandParser parser = new CompleteCommandParser();
-    private final LabelMatchesKeywordPredicate FRIENDS_LABEL = new LabelMatchesKeywordPredicate("friends");
 
     @Test
     public void parse_validArgs_returnsCompleteCommand() {
@@ -29,11 +29,11 @@ public class CompleteCommandParserTest {
 
         // Arguments with leading whitepaces
         assertParseSuccess(parser, " 1", new CompleteCommand(INDEX_FIRST_TASK));
-        assertParseSuccess(parser, " l/friends", new CompleteCommand(FRIENDS_LABEL));
+        assertParseSuccess(parser, " l/friends", new CompleteCommand(LABEL_FRIENDS));
 
         // Arguments with leading and trailing whitespaces
         assertParseSuccess(parser, "  1  ", new CompleteCommand(INDEX_FIRST_TASK));
-        assertParseSuccess(parser, "  l/ friends  ", new CompleteCommand(FRIENDS_LABEL));
+        assertParseSuccess(parser, "  l/ friends  ", new CompleteCommand(LABEL_FRIENDS));
 
     }
 
@@ -42,7 +42,7 @@ public class CompleteCommandParserTest {
 
         // No valid symbols
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                CompleteCommand.MESSAGE_USAGE));
+            CompleteCommand.MESSAGE_USAGE));
 
         // No whitespace before label
         assertParseFailure(parser, "l/friends", String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
@@ -30,4 +30,5 @@ public class CompleteCommandParserTest {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 CompleteCommand.MESSAGE_USAGE));
     }
+
 }

--- a/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
@@ -11,11 +11,8 @@ import seedu.address.logic.commands.CompleteCommand;
 import seedu.address.model.task.LabelMatchesKeywordPredicate;
 
 /**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the CompleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the CompleteCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * Tests the CompleteCommandParser's ability to handle Index(es) and Labels
+ * and parse accordingly.
  */
 public class CompleteCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 import org.junit.Test;
 
 import seedu.address.logic.commands.CompleteCommand;
+import seedu.address.model.task.LabelMatchesKeywordPredicate;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -19,16 +20,45 @@ import seedu.address.logic.commands.CompleteCommand;
 public class CompleteCommandParserTest {
 
     private CompleteCommandParser parser = new CompleteCommandParser();
+    private final LabelMatchesKeywordPredicate FRIENDS_LABEL = new LabelMatchesKeywordPredicate("friends");
 
     @Test
     public void parse_validArgs_returnsCompleteCommand() {
+        // Arguments with no whitespaces
         assertParseSuccess(parser, "1", new CompleteCommand(INDEX_FIRST_TASK));
+
+        // Arguments with leading whitepaces
+        assertParseSuccess(parser, " 1", new CompleteCommand(INDEX_FIRST_TASK));
+        assertParseSuccess(parser, " l/friends", new CompleteCommand(FRIENDS_LABEL));
+
+        // Arguments with leading and trailing whitespaces
+        assertParseSuccess(parser, "  1  ", new CompleteCommand(INDEX_FIRST_TASK));
+        assertParseSuccess(parser, "  l/ friends  ", new CompleteCommand(FRIENDS_LABEL));
+
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
+
+        // No valid symbols
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 CompleteCommand.MESSAGE_USAGE));
+
+        // No whitespace before label
+        assertParseFailure(parser, "l/friends", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            CompleteCommand.MESSAGE_USAGE));
+
+        // Mix of Label and Index symbols
+        assertParseFailure(parser, "1 l/friends", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            CompleteCommand.MESSAGE_USAGE));
+
+        // Multiple Index symbols
+        assertParseFailure(parser, "1 2", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            CompleteCommand.MESSAGE_USAGE));
+
+        // Improper Label symbol
+        assertParseFailure(parser, " l\\friends", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            CompleteCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/test/java/seedu/address/model/VersionedTaskManagerTest.java
+++ b/src/test/java/seedu/address/model/VersionedTaskManagerTest.java
@@ -29,40 +29,76 @@ public class VersionedTaskManagerTest {
 
         versionedTaskManager.commit();
         assertTaskManagerListStatus(versionedTaskManager,
-                Collections.singletonList(emptyTaskManager),
-                emptyTaskManager,
-                Collections.emptyList());
+            Collections.singletonList(emptyTaskManager),
+            emptyTaskManager,
+            Collections.emptyList());
     }
 
     @Test
     public void commit_multipleTaskManagerPointerAtEndOfStateList_noStatesRemovedCurrentStateSaved() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
 
         versionedTaskManager.commit();
         assertTaskManagerListStatus(versionedTaskManager,
-                Arrays.asList(emptyTaskManager, taskManagerWithAmy, taskManagerWithBob),
-                taskManagerWithBob,
-                Collections.emptyList());
+            Arrays.asList(emptyTaskManager, taskManagerWithAmy, taskManagerWithBob),
+            taskManagerWithBob,
+            Collections.emptyList());
     }
 
     @Test
     public void commit_multipleTaskManagerPointerNotAtEndOfStateList_statesAfterPointerRemovedCurrentStateSaved() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 2);
 
         versionedTaskManager.commit();
         assertTaskManagerListStatus(versionedTaskManager,
-                Collections.singletonList(emptyTaskManager),
-                emptyTaskManager,
-                Collections.emptyList());
+            Collections.singletonList(emptyTaskManager),
+            emptyTaskManager,
+            Collections.emptyList());
+    }
+
+    @Test
+    public void rollback_singleTaskManagerNoStateChanged_noChange() {
+        VersionedTaskManager versionedTaskManager = prepareTaskManagerList(emptyTaskManager);
+
+        versionedTaskManager.rollback();
+        assertTaskManagerListStatus(versionedTaskManager,
+            Collections.emptyList(),
+            emptyTaskManager,
+            Collections.emptyList());
+    }
+
+    @Test
+    public void rollback_multipleTaskManagerPointerAtEndOfStateList_noChange() {
+        VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+
+        versionedTaskManager.rollback();
+        assertTaskManagerListStatus(versionedTaskManager,
+            Arrays.asList(emptyTaskManager, taskManagerWithAmy),
+            taskManagerWithBob,
+            Collections.emptyList());
+    }
+
+    @Test
+    public void rollback_multipleTaskManagerPointerNotAtEndOfStateList_statePointerResetToEndOfStateList() {
+        VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+        shiftCurrentStatePointerLeftwards(versionedTaskManager, 2);
+
+        versionedTaskManager.rollback();
+        assertTaskManagerListStatus(versionedTaskManager,
+            Arrays.asList(emptyTaskManager, taskManagerWithAmy),
+            taskManagerWithBob,
+            Collections.emptyList());
     }
 
     @Test
     public void canUndo_multipleTaskManagerPointerAtEndOfStateList_returnsTrue() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
 
         assertTrue(versionedTaskManager.canUndo());
     }
@@ -70,7 +106,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void canUndo_multipleTaskManagerPointerAtStartOfStateList_returnsTrue() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 1);
 
         assertTrue(versionedTaskManager.canUndo());
@@ -86,7 +122,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void canUndo_multipleTaskManagerPointerAtStartOfStateList_returnsFalse() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 2);
 
         assertFalse(versionedTaskManager.canUndo());
@@ -95,7 +131,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void canRedo_multipleTaskManagerPointerNotAtEndOfStateList_returnsTrue() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 1);
 
         assertTrue(versionedTaskManager.canRedo());
@@ -104,7 +140,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void canRedo_multipleTaskManagerPointerAtStartOfStateList_returnsTrue() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 2);
 
         assertTrue(versionedTaskManager.canRedo());
@@ -120,7 +156,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void canRedo_multipleTaskManagerPointerAtEndOfStateList_returnsFalse() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
 
         assertFalse(versionedTaskManager.canRedo());
     }
@@ -128,26 +164,26 @@ public class VersionedTaskManagerTest {
     @Test
     public void undo_multipleTaskManagerPointerAtEndOfStateList_success() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
 
         versionedTaskManager.undo();
         assertTaskManagerListStatus(versionedTaskManager,
-                Collections.singletonList(emptyTaskManager),
-                taskManagerWithAmy,
-                Collections.singletonList(taskManagerWithBob));
+            Collections.singletonList(emptyTaskManager),
+            taskManagerWithAmy,
+            Collections.singletonList(taskManagerWithBob));
     }
 
     @Test
     public void undo_multipleTaskManagerPointerNotAtStartOfStateList_success() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 1);
 
         versionedTaskManager.undo();
         assertTaskManagerListStatus(versionedTaskManager,
-                Collections.emptyList(),
-                emptyTaskManager,
-                Arrays.asList(taskManagerWithAmy, taskManagerWithBob));
+            Collections.emptyList(),
+            emptyTaskManager,
+            Arrays.asList(taskManagerWithAmy, taskManagerWithBob));
     }
 
     @Test
@@ -160,7 +196,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void undo_multipleTaskManagerPointerAtStartOfStateList_throwsNoUndoableStateException() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 2);
 
         assertThrows(VersionedTaskManager.NoUndoableStateException.class, versionedTaskManager::undo);
@@ -169,27 +205,27 @@ public class VersionedTaskManagerTest {
     @Test
     public void redo_multipleTaskManagerPointerNotAtEndOfStateList_success() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 1);
 
         versionedTaskManager.redo();
         assertTaskManagerListStatus(versionedTaskManager,
-                Arrays.asList(emptyTaskManager, taskManagerWithAmy),
-                taskManagerWithBob,
-                Collections.emptyList());
+            Arrays.asList(emptyTaskManager, taskManagerWithAmy),
+            taskManagerWithBob,
+            Collections.emptyList());
     }
 
     @Test
     public void redo_multipleTaskManagerPointerAtStartOfStateList_success() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 2);
 
         versionedTaskManager.redo();
         assertTaskManagerListStatus(versionedTaskManager,
-                Collections.singletonList(emptyTaskManager),
-                taskManagerWithAmy,
-                Collections.singletonList(taskManagerWithBob));
+            Collections.singletonList(emptyTaskManager),
+            taskManagerWithAmy,
+            Collections.singletonList(taskManagerWithBob));
     }
 
     @Test
@@ -202,7 +238,7 @@ public class VersionedTaskManagerTest {
     @Test
     public void redo_multipleTaskManagerPointerAtEndOfStateList_throwsNoRedoableStateException() {
         VersionedTaskManager versionedTaskManager = prepareTaskManagerList(
-                emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
+            emptyTaskManager, taskManagerWithAmy, taskManagerWithBob);
 
         assertThrows(VersionedTaskManager.NoRedoableStateException.class, versionedTaskManager::redo);
     }
@@ -230,7 +266,7 @@ public class VersionedTaskManagerTest {
 
         // different current pointer index -> returns false
         VersionedTaskManager differentCurrentStatePointer = prepareTaskManagerList(
-                taskManagerWithAmy, taskManagerWithBob);
+            taskManagerWithAmy, taskManagerWithBob);
         shiftCurrentStatePointerLeftwards(versionedTaskManager, 1);
         assertFalse(versionedTaskManager.equals(differentCurrentStatePointer));
     }

--- a/src/test/java/seedu/address/model/task/LabelMatchesKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/LabelMatchesKeywordPredicateTest.java
@@ -1,0 +1,70 @@
+package seedu.address.model.task;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import seedu.address.testutil.TaskBuilder;
+
+public class LabelMatchesKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstDummyKeyword = "habibi";
+        String secondDummyKeyword = "hablahabla";
+        LabelMatchesKeywordPredicate firstPredicate = new LabelMatchesKeywordPredicate(firstDummyKeyword);
+        LabelMatchesKeywordPredicate secondPredicate = new LabelMatchesKeywordPredicate(secondDummyKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        LabelMatchesKeywordPredicate firstPredicateCopy = new LabelMatchesKeywordPredicate(firstDummyKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different task -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_labelMatchesKeyword_returnsTrue() {
+        // One Label
+        LabelMatchesKeywordPredicate predicate = new LabelMatchesKeywordPredicate("Urgent");
+        assertTrue(predicate.test(new TaskBuilder().withLabels("Urgent").build()));
+
+        // Multiple Labels
+        assertTrue(predicate.test(new TaskBuilder().withLabels("Urgent", "Critical", "VeryReallyUrgent").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        LabelMatchesKeywordPredicate predicate = new LabelMatchesKeywordPredicate("Severe");
+        assertFalse(predicate.test(new TaskBuilder().withLabels("Urgent").build()));
+
+        // Keywords match priority value, description and name, but does not match label
+        // DueDate is not tested as Label's format cannot match DueDate's
+        predicate = new LabelMatchesKeywordPredicate("2");
+        assertFalse(predicate.test(new TaskBuilder().withPriorityValue("2").build()));
+
+        predicate = new LabelMatchesKeywordPredicate("Milestone1");
+        assertFalse(predicate.test(new TaskBuilder().withName("Milestone1").build()));
+
+        predicate = new LabelMatchesKeywordPredicate("Donoteat");
+        assertFalse(predicate.test(new TaskBuilder().withDescription("Donoteat").build()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_emptyString_throwsException() {
+        // Empty string as a keyword
+        LabelMatchesKeywordPredicate predicate = new LabelMatchesKeywordPredicate("");
+    }
+
+}


### PR DESCRIPTION
Fixes #73, #77 

# Changelog:

## Command upgrade
### Upgrade CompleteCommand to handle batch complete via label
- src/main/java/seedu/address/logic/commands/CompleteCommand.java
#### Tests for CompleteCommand
- src/test/java/seedu/address/logic/commands/CommandTestUtil.java
- src/test/java/seedu/address/logic/commands/CompleteCommandTest.java


### Upgrade CompleteCommandParser to parser labels
- src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
#### Parser test
- src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java



## Auxilliary implementation changes to allow for command upgrade
### Implement Rollback for Model
- src/main/java/seedu/address/model/Model.java
- src/main/java/seedu/address/model/ModelManager.java
- src/main/java/seedu/address/model/VersionedTaskManager.java
#### Tests for rollback
- src/test/java/seedu/address/model/VersionedTaskManagerTest.java

#### Update test following  new implementation
- src/test/java/seedu/address/logic/commands/AddCommandTest.java

### Introduce new predicate
- src/main/java/seedu/address/model/task/LabelMatchesKeywordPredicate.java
#### Test for predicate
- src/test/java/seedu/address/model/task/LabelMatchesKeywordPredicateTest.java