### PR TITLE
Achievements field

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -132,7 +132,7 @@ public class CompleteCommand extends Command {
 
         Task completedTask = createCompletedTask(taskToComplete);
 
-        modelToUpdate.updateTask(taskToComplete, completedTask);
+        modelToUpdate.updateTaskStatus(taskToComplete, completedTask);
         return completedTask.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -49,7 +49,7 @@ public class CompleteCommand extends Command {
             throw new CommandException(MESSAGE_ALREADY_COMPLETED);
         }
 
-        model.updateTask(taskToComplete, completedTask);
+        model.updateTaskStatus(taskToComplete, completedTask);
         model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         model.commitTaskManager();
         return new CommandResult(String.format(MESSAGE_SUCCESS, completedTask));

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -49,6 +49,14 @@ public interface Model {
     void updateTask(Task target, Task editedTask);
 
     /**
+     * Replaces the given task {@code target} with {@code updatedTask}.
+     * Update the xp field in achievement record of the task manager according to task status change.
+     * {@code target} must exist in the task manager.
+     * {@code target} and {@code updatedTask} have the same identity but different status.
+     */
+    void updateTaskStatus(Task target, Task updatedTask);
+
+    /**
      * Returns an unmodifiable view of the filtered task list
      */
     ObservableList<Task> getFilteredTaskList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -85,6 +85,15 @@ public class ModelManager extends ComponentManager implements Model {
         indicateTaskManagerChanged();
     }
 
+    @Override
+    public void updateTaskStatus(Task target, Task updatedTask) {
+        requireAllNonNull(target, updatedTask);
+
+        versionedTaskManager.updateTask(target, updatedTask);
+        versionedTaskManager.updateAchievement(500);
+        indicateTaskManagerChanged();
+    }
+
     //=========== Filtered Task List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -90,7 +90,8 @@ public class ModelManager extends ComponentManager implements Model {
         requireAllNonNull(target, updatedTask);
 
         versionedTaskManager.updateTask(target, updatedTask);
-        versionedTaskManager.updateXp(500);
+        //temporarily taking the xp of each task to be 50
+        versionedTaskManager.updateXp(50);
         indicateTaskManagerChanged();
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -90,7 +90,7 @@ public class ModelManager extends ComponentManager implements Model {
         requireAllNonNull(target, updatedTask);
 
         versionedTaskManager.updateTask(target, updatedTask);
-        versionedTaskManager.updateXP(500);
+        versionedTaskManager.updateXp(500);
         indicateTaskManagerChanged();
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -90,7 +90,7 @@ public class ModelManager extends ComponentManager implements Model {
         requireAllNonNull(target, updatedTask);
 
         versionedTaskManager.updateTask(target, updatedTask);
-        versionedTaskManager.updateAchievement(500);
+        versionedTaskManager.updateXP(500);
         indicateTaskManagerChanged();
     }
 

--- a/src/main/java/seedu/address/model/ReadOnlyTaskManager.java
+++ b/src/main/java/seedu/address/model/ReadOnlyTaskManager.java
@@ -1,6 +1,8 @@
 package seedu.address.model;
 
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
+import seedu.address.model.achievement.AchievementRecord;
 import seedu.address.model.task.Task;
 
 /**
@@ -9,9 +11,14 @@ import seedu.address.model.task.Task;
 public interface ReadOnlyTaskManager {
 
     /**
-     * Returns an unmodifiable view of the persons list.
-     * This list will not contain any duplicate persons.
+     * Returns an unmodifiable view of the tasks list.
+     * This list will not contain any duplicate tasks.
      */
     ObservableList<Task> getTaskList();
+
+    /**
+     * Returns an unmodifiable view of the achievement record.
+     */
+    SimpleObjectProperty<AchievementRecord> getAchievementRecord();
 
 }

--- a/src/main/java/seedu/address/model/TaskManager.java
+++ b/src/main/java/seedu/address/model/TaskManager.java
@@ -110,7 +110,7 @@ public class TaskManager implements ReadOnlyTaskManager {
     
     //// achievement related operation
     
-    public void updateAchievement(Integer xp) {
+    public void updateXP(Integer xp) {
         requireNonNull(xp);
         
         achievements.updateXP(xp);

--- a/src/main/java/seedu/address/model/TaskManager.java
+++ b/src/main/java/seedu/address/model/TaskManager.java
@@ -107,6 +107,14 @@ public class TaskManager implements ReadOnlyTaskManager {
     public void removeTask(Task key) {
         tasks.remove(key);
     }
+    
+    //// achievement related operation
+    
+    public void updateAchievement(Integer xp) {
+        requireNonNull(xp);
+        
+        achievements.updateXP(xp);
+    }
 
     //// util methods
 

--- a/src/main/java/seedu/address/model/TaskManager.java
+++ b/src/main/java/seedu/address/model/TaskManager.java
@@ -107,13 +107,16 @@ public class TaskManager implements ReadOnlyTaskManager {
     public void removeTask(Task key) {
         tasks.remove(key);
     }
-    
+
     //// achievement related operation
-    
-    public void updateXP(Integer xp) {
+
+    /**
+     * Updates the Xp in the {@code AchievementRecord} of the {@code TaskManager} with the new xp value.
+     */
+    public void updateXp(Integer xp) {
         requireNonNull(xp);
-        
-        achievements.updateXP(xp);
+
+        achievements.updateXp(xp);
     }
 
     //// util methods
@@ -139,7 +142,7 @@ public class TaskManager implements ReadOnlyTaskManager {
         return other == this // short circuit if same object
                 || (other instanceof TaskManager // instanceof handles nulls
                 && tasks.equals(((TaskManager) other).tasks)
-                && achievements.equals(((TaskManager)other).achievements));
+                && achievements.equals(((TaskManager) other).achievements));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/TaskManager.java
+++ b/src/main/java/seedu/address/model/TaskManager.java
@@ -3,8 +3,11 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
+import seedu.address.model.achievement.AchievementRecord;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.UniqueTaskList;
 
@@ -15,6 +18,7 @@ import seedu.address.model.task.UniqueTaskList;
 public class TaskManager implements ReadOnlyTaskManager {
 
     private final UniqueTaskList tasks;
+    private final AchievementRecord achievements;
 
     /*
      * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
@@ -25,6 +29,7 @@ public class TaskManager implements ReadOnlyTaskManager {
      */
     {
         tasks = new UniqueTaskList();
+        achievements = new AchievementRecord();
     }
 
     public TaskManager() {
@@ -38,7 +43,7 @@ public class TaskManager implements ReadOnlyTaskManager {
         resetData(toBeCopied);
     }
 
-    //// list overwrite operations
+    //// list and achievement overwrite operations
 
     /**
      * Replaces the contents of the task list with {@code tasks}.
@@ -49,12 +54,21 @@ public class TaskManager implements ReadOnlyTaskManager {
     }
 
     /**
+     * Replaces the contents of the task list with {@code tasks}.
+     * {@code tasks} must not contain duplicate tasks.
+     */
+    public void setAchievements(AchievementRecord achievements) {
+        this.achievements.resetData(achievements);
+    }
+
+    /**
      * Resets the existing data of this {@code TaskManager} with {@code newData}.
      */
     public void resetData(ReadOnlyTaskManager newData) {
         requireNonNull(newData);
 
         setTasks(newData.getTaskList());
+        setAchievements(newData.getAchievementRecord().get());
     }
 
     //// task-level operations
@@ -108,14 +122,20 @@ public class TaskManager implements ReadOnlyTaskManager {
     }
 
     @Override
+    public SimpleObjectProperty<AchievementRecord> getAchievementRecord() {
+        return achievements.asSimpleObjectProperty();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TaskManager // instanceof handles nulls
-                && tasks.equals(((TaskManager) other).tasks));
+                && tasks.equals(((TaskManager) other).tasks)
+                && achievements.equals(((TaskManager)other).achievements));
     }
 
     @Override
     public int hashCode() {
-        return tasks.hashCode();
+        return Objects.hash(tasks, achievements);
     }
 }

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -61,6 +61,13 @@ public class AchievementRecord {
         setLevel(newData.getLevel());
     }
 
+    public void updateXP(Integer xp) {
+        requireNonNull(xp);
+
+        Integer newXpValue = this.xp.getXp() + xp;
+        this.setXp(new XP(newXpValue));
+    }
+
     /**
      * Returns the backing object as an {@code SimpleObjectProperty}.
      */

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -66,6 +66,30 @@ public class AchievementRecord {
 
         Integer newXpValue = this.xp.getXp() + xp;
         this.setXp(new XP(newXpValue));
+        updateLevelWithXP(newXpValue);
+    }
+    
+    public void updateLevelWithXP(Integer xp) {
+        Level newLevel = getMatchingLevel(xp);
+        if(!this.level.equals(newLevel)) {
+            setLevel(newLevel);
+        }
+    }
+    
+    public Level getMatchingLevel(Integer xp) {
+        if(xp < Level.LEVEL_1.getMaxXP()) {
+            return Level.LEVEL_1;
+        }
+        if(xp < Level.LEVEL_2.getMaxXP()) {
+            return level.LEVEL_2;
+        }
+        if(xp < Level.LEVEL_3.getMaxXP()) {
+            return level.LEVEL_3;
+        }
+        if(xp < Level.LEVEL_4.getMaxXP()) {
+            return level.LEVEL_4;
+        }
+        return Level.LEVEL_5;
     }
 
     /**

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -1,0 +1,78 @@
+package seedu.address.model.achievement;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import javafx.beans.property.SimpleObjectProperty;
+
+/**
+ * Represents a record of the user's achievements while using the task manager.
+ * Achievements include the experience points(xp) earned by completing the task and the level a user has reached.
+ * Guarantees: details are present and not null.
+ */
+public class AchievementRecord {
+
+    private XP xp;
+    private Level level;
+
+
+    /**
+     * Constructs a {@code AchievementRecord}.
+     * XP value is initialized to 0 and Level initialized to LEVEL_1.
+     */
+    public AchievementRecord() {
+        this.xp = new XP();
+        this.level = Level.LEVEL_1;
+    }
+
+    /**
+     * Constructs a {@code AchievementRecord}.
+     * Both fields must be present.
+     */
+    public AchievementRecord(XP xp, Level level) {
+        requireAllNonNull(xp, level);
+        this.xp = xp;
+        this.level = level;
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(Level level) {
+        this.level = level;
+    }
+
+    public XP getXp() {
+        return xp;
+    }
+
+    public void setXp(XP xp) {
+        this.xp = xp;
+    }
+
+    /**
+     * Resets the existing data of this {@code AchievementRecord} with {@code newData}.
+     */
+    public void resetData(AchievementRecord newData) {
+        requireNonNull(newData);
+
+        setXp(newData.getXp());
+        setLevel(newData.getLevel());
+    }
+
+    /**
+     * Returns the backing object as an {@code SimpleObjectProperty}.
+     */
+    public SimpleObjectProperty<AchievementRecord> asSimpleObjectProperty() {
+        return new SimpleObjectProperty<>(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AchievementRecord // instanceof handles nulls
+                && xp.equals(((AchievementRecord) other).xp))
+                && level.equals(((AchievementRecord) other).level);
+    }
+}

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -61,6 +61,10 @@ public class AchievementRecord {
         setLevel(newData.getLevel());
     }
 
+    /**
+     * Update the XP field of this {@code AchievementRecord} with new xp value.
+     * Triggers the update of Level with xp.
+     */
     public void updateXP(Integer xp) {
         requireNonNull(xp);
 
@@ -68,14 +72,21 @@ public class AchievementRecord {
         this.setXp(new XP(newXpValue));
         updateLevelWithXP(newXpValue);
     }
-    
+
+    /**
+     * Update the Level field of this {@code AchievementRecord} with new xp value.
+     */
     public void updateLevelWithXP(Integer xp) {
         Level newLevel = getMatchingLevel(xp);
         if(!this.level.equals(newLevel)) {
             setLevel(newLevel);
         }
     }
-    
+
+    /**
+     * Returns the corresponding {@code Level} of the current XP value.
+     * Maximum level is level 5.
+     */
     public Level getMatchingLevel(Integer xp) {
         if(xp < Level.LEVEL_1.getMaxXP()) {
             return Level.LEVEL_1;

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -12,16 +12,16 @@ import javafx.beans.property.SimpleObjectProperty;
  */
 public class AchievementRecord {
 
-    private XP xp;
+    private Xp xp;
     private Level level;
 
 
     /**
      * Constructs a {@code AchievementRecord}.
-     * XP value is initialized to 0 and Level initialized to LEVEL_1.
+     * Xp value is initialized to 0 and Level initialized to LEVEL_1.
      */
     public AchievementRecord() {
-        this.xp = new XP();
+        this.xp = new Xp();
         this.level = Level.LEVEL_1;
     }
 
@@ -29,7 +29,7 @@ public class AchievementRecord {
      * Constructs a {@code AchievementRecord}.
      * Both fields must be present.
      */
-    public AchievementRecord(XP xp, Level level) {
+    public AchievementRecord(Xp xp, Level level) {
         requireAllNonNull(xp, level);
         this.xp = xp;
         this.level = level;
@@ -43,11 +43,11 @@ public class AchievementRecord {
         this.level = level;
     }
 
-    public XP getXp() {
+    public Xp getXp() {
         return xp;
     }
 
-    public void setXp(XP xp) {
+    public void setXp(Xp xp) {
         this.xp = xp;
     }
 
@@ -62,42 +62,42 @@ public class AchievementRecord {
     }
 
     /**
-     * Update the XP field of this {@code AchievementRecord} with new xp value.
+     * Updates the Xp field of this {@code AchievementRecord} with new xp value.
      * Triggers the update of Level with xp.
      */
-    public void updateXP(Integer xp) {
+    public void updateXp(Integer xp) {
         requireNonNull(xp);
 
         Integer newXpValue = this.xp.getXp() + xp;
-        this.setXp(new XP(newXpValue));
-        updateLevelWithXP(newXpValue);
+        this.setXp(new Xp(newXpValue));
+        updateLevelWithXp(newXpValue);
     }
 
     /**
-     * Update the Level field of this {@code AchievementRecord} with new xp value.
+     * Updates the Level field of this {@code AchievementRecord} with new xp value.
      */
-    public void updateLevelWithXP(Integer xp) {
+    public void updateLevelWithXp(Integer xp) {
         Level newLevel = getMatchingLevel(xp);
-        if(!this.level.equals(newLevel)) {
+        if (!this.level.equals(newLevel)) {
             setLevel(newLevel);
         }
     }
 
     /**
-     * Returns the corresponding {@code Level} of the current XP value.
+     * Returns the corresponding {@code Level} of the current Xp value.
      * Maximum level is level 5.
      */
     public Level getMatchingLevel(Integer xp) {
-        if(xp < Level.LEVEL_1.getMaxXP()) {
+        if (xp < Level.LEVEL_1.getMaxXp()) {
             return Level.LEVEL_1;
         }
-        if(xp < Level.LEVEL_2.getMaxXP()) {
+        if (xp < Level.LEVEL_2.getMaxXp()) {
             return level.LEVEL_2;
         }
-        if(xp < Level.LEVEL_3.getMaxXP()) {
+        if (xp < Level.LEVEL_3.getMaxXp()) {
             return level.LEVEL_3;
         }
-        if(xp < Level.LEVEL_4.getMaxXP()) {
+        if (xp < Level.LEVEL_4.getMaxXp()) {
             return level.LEVEL_4;
         }
         return Level.LEVEL_5;

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -90,17 +90,15 @@ public class AchievementRecord {
     public Level getMatchingLevel(Integer xp) {
         if (xp < Level.LEVEL_1.getMaxXp()) {
             return Level.LEVEL_1;
-        }
-        if (xp < Level.LEVEL_2.getMaxXp()) {
+        } else if (xp < Level.LEVEL_2.getMaxXp()) {
             return level.LEVEL_2;
-        }
-        if (xp < Level.LEVEL_3.getMaxXp()) {
+        } else if (xp < Level.LEVEL_3.getMaxXp()) {
             return level.LEVEL_3;
-        }
-        if (xp < Level.LEVEL_4.getMaxXp()) {
+        } else if (xp < Level.LEVEL_4.getMaxXp()) {
             return level.LEVEL_4;
+        } else {
+            return Level.LEVEL_5;
         }
-        return Level.LEVEL_5;
     }
 
     /**

--- a/src/main/java/seedu/address/model/achievement/Level.java
+++ b/src/main/java/seedu/address/model/achievement/Level.java
@@ -3,6 +3,7 @@ package seedu.address.model.achievement;
 /**
  * Represent the level of achievement in reached by the user.
  * There are only 5 valid levels, LEVEL_1 to LEVEL_5.
+ * Each level has a name and a range of xp that the level corresponds to.
  */
 public enum Level {
     LEVEL_1("lvl.1", 0, 500),
@@ -14,17 +15,17 @@ public enum Level {
     public static final String MESSAGE_LEVEL_CONSTRAINTS =
             "Level should only have the value lvl.n, where n is integer from 1 to 5";
     public static final String LEVEL_VALIDATION_REGEX = "lvl.[1-5]";
-    private String levelString;
+    private String levelName;
     private Integer minXP;
     private Integer maxXP;
 
     /**
      * Constructs a {@code Level}.
      *
-     * @param levelString a string with corresponding Level object.
+     * @param levelName a string with corresponding Level object.
      */
-    Level(String levelString, Integer minXP, Integer maxXP) {
-        this.levelString = levelString;
+    Level(String levelName, Integer minXP, Integer maxXP) {
+        this.levelName = levelName;
         this.minXP = minXP;
         this.maxXP = maxXP;
     }
@@ -40,9 +41,9 @@ public enum Level {
     /**
      * Returns true if a given string is a valid Level value.
      */
-    public static boolean isValidLevel(String value) {
+    public static boolean isValidLevel(String name) {
         try {
-            return value.matches(LEVEL_VALIDATION_REGEX);
+            return name.matches(LEVEL_VALIDATION_REGEX);
         } catch (NullPointerException ex) {
             return false;
         }
@@ -62,6 +63,6 @@ public enum Level {
 
     @Override
     public String toString() {
-        return levelString;
+        return levelName;
     }
 }

--- a/src/main/java/seedu/address/model/achievement/Level.java
+++ b/src/main/java/seedu/address/model/achievement/Level.java
@@ -9,6 +9,7 @@ public enum Level {
 
     public static final String MESSAGE_LEVEL_CONSTRAINTS =
             "Level should only have the value lvl.n, where n is integer from 1 to 5";
+    public static final String LEVEL_VALIDATION_REGEX = "lvl.[1-5]";
     private String levelValue;
 
     /**
@@ -20,26 +21,27 @@ public enum Level {
         this.levelValue = levelValue;
     }
 
-//    /**
-//     * Returns true if a given string is a valid Status value.
-//     */
-//    public static boolean isValidStatus(String value) {
-//        try {
-//            return value.equals("IN PROGRESS") || value.equals("FINISHED") || value.equals("OVERDUE");
-//        } catch (NullPointerException ex) {
-//            return false;
-//        }
-//    }
-//
-//    /**
-//     * Returns the corresponding status object of {@param value}.
-//     */
-//    public static Status getStatusFromValue(String value) {
-//        if (!isValidStatus(value)) {
-//            throw new IllegalArgumentException();
-//        }
-//        return value.equals("IN PROGRESS") ? Status.IN_PROGRESS : Status.valueOf(value);
-//    }
+    /**
+     * Returns true if a given string is a valid Level value.
+     */
+    public static boolean isValidLevel(String value) {
+        try {
+            return value.matches(LEVEL_VALIDATION_REGEX);
+        } catch (NullPointerException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the corresponding level object of {@param string}.
+     */
+    public static Level fromString(String string) {
+        if (!isValidLevel(string)) {
+            throw new IllegalArgumentException();
+        }
+        int index = Character.digit(string.charAt(4), 10);
+        return (Level.values())[index];
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/achievement/Level.java
+++ b/src/main/java/seedu/address/model/achievement/Level.java
@@ -16,26 +16,26 @@ public enum Level {
             "Level should only have the value lvl.n, where n is integer from 1 to 5";
     public static final String LEVEL_VALIDATION_REGEX = "lvl.[1-5]";
     private String levelName;
-    private Integer minXP;
-    private Integer maxXP;
+    private Integer minXp;
+    private Integer maxXp;
 
     /**
      * Constructs a {@code Level}.
      *
      * @param levelName a string with corresponding Level object.
      */
-    Level(String levelName, Integer minXP, Integer maxXP) {
+    Level(String levelName, Integer minXp, Integer maxXp) {
         this.levelName = levelName;
-        this.minXP = minXP;
-        this.maxXP = maxXP;
+        this.minXp = minXp;
+        this.maxXp = maxXp;
     }
-    
-    public Integer getMinXP() {
-        return this.minXP;
+
+    public Integer getMinXp() {
+        return this.minXp;
     }
-    
-    public Integer getMaxXP() {
-        return this.maxXP;
+
+    public Integer getMaxXp() {
+        return this.maxXp;
     }
 
     /**

--- a/src/main/java/seedu/address/model/achievement/Level.java
+++ b/src/main/java/seedu/address/model/achievement/Level.java
@@ -5,20 +5,36 @@ package seedu.address.model.achievement;
  * There are only 5 valid levels, LEVEL_1 to LEVEL_5.
  */
 public enum Level {
-    LEVEL_1("lvl.1"), LEVEL_2("lvl.2"), LEVEL_3("lvl.3"), LEVEL_4("lvl.4"), LEVEL_5("lvl.5");
+    LEVEL_1("lvl.1", 0, 500),
+    LEVEL_2("lvl.2", 500, 1000),
+    LEVEL_3("lvl.3", 1000, 2000),
+    LEVEL_4("lvl.4", 2000, 4000),
+    LEVEL_5("lvl.5", 4000, 100000);
 
     public static final String MESSAGE_LEVEL_CONSTRAINTS =
             "Level should only have the value lvl.n, where n is integer from 1 to 5";
     public static final String LEVEL_VALIDATION_REGEX = "lvl.[1-5]";
-    private String levelValue;
+    private String levelString;
+    private Integer minXP;
+    private Integer maxXP;
 
     /**
      * Constructs a {@code Level}.
      *
-     * @param levelValue A valid statusValue.
+     * @param levelString a string with corresponding Level object.
      */
-    Level(String levelValue) {
-        this.levelValue = levelValue;
+    Level(String levelString, Integer minXP, Integer maxXP) {
+        this.levelString = levelString;
+        this.minXP = minXP;
+        this.maxXP = maxXP;
+    }
+    
+    public Integer getMinXP() {
+        return this.minXP;
+    }
+    
+    public Integer getMaxXP() {
+        return this.maxXP;
     }
 
     /**
@@ -46,6 +62,6 @@ public enum Level {
 
     @Override
     public String toString() {
-        return levelValue;
+        return levelString;
     }
 }

--- a/src/main/java/seedu/address/model/achievement/Level.java
+++ b/src/main/java/seedu/address/model/achievement/Level.java
@@ -1,0 +1,48 @@
+package seedu.address.model.achievement;
+
+/**
+ * Represent the level of achievement in reached by the user.
+ * There are only 5 valid levels, LEVEL_1 to LEVEL_5.
+ */
+public enum Level {
+    LEVEL_1("lvl.1"), LEVEL_2("lvl.2"), LEVEL_3("lvl.3"), LEVEL_4("lvl.4"), LEVEL_5("lvl.5");
+
+    public static final String MESSAGE_LEVEL_CONSTRAINTS =
+            "Level should only have the value lvl.n, where n is integer from 1 to 5";
+    private String levelValue;
+
+    /**
+     * Constructs a {@code Level}.
+     *
+     * @param levelValue A valid statusValue.
+     */
+    Level(String levelValue) {
+        this.levelValue = levelValue;
+    }
+
+//    /**
+//     * Returns true if a given string is a valid Status value.
+//     */
+//    public static boolean isValidStatus(String value) {
+//        try {
+//            return value.equals("IN PROGRESS") || value.equals("FINISHED") || value.equals("OVERDUE");
+//        } catch (NullPointerException ex) {
+//            return false;
+//        }
+//    }
+//
+//    /**
+//     * Returns the corresponding status object of {@param value}.
+//     */
+//    public static Status getStatusFromValue(String value) {
+//        if (!isValidStatus(value)) {
+//            throw new IllegalArgumentException();
+//        }
+//        return value.equals("IN PROGRESS") ? Status.IN_PROGRESS : Status.valueOf(value);
+//    }
+
+    @Override
+    public String toString() {
+        return levelValue;
+    }
+}

--- a/src/main/java/seedu/address/model/achievement/Level.java
+++ b/src/main/java/seedu/address/model/achievement/Level.java
@@ -39,7 +39,8 @@ public enum Level {
         if (!isValidLevel(string)) {
             throw new IllegalArgumentException();
         }
-        int index = Character.digit(string.charAt(4), 10);
+        int offset = -1;
+        int index = Character.digit(string.charAt(4), 10) + offset;
         return (Level.values())[index];
     }
 

--- a/src/main/java/seedu/address/model/achievement/XP.java
+++ b/src/main/java/seedu/address/model/achievement/XP.java
@@ -1,0 +1,43 @@
+package seedu.address.model.achievement;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents the experience point(xp) earned by the user while using the task manager.
+ */
+public class XP {
+    
+    public static final String MESSAGE_XP_CONSTRAINTS =
+            "XP should have integer values.";
+    private final Integer xp;
+
+    /**
+     * Constructs an XP of value 0.
+     */
+    public XP() {
+        this.xp = 0;
+    }
+
+    /**
+     * Constructs a {@code XP}.
+     *
+     * @param xp A valid xp value.
+     */
+    public XP(Integer xp) {
+        requireNonNull(xp);
+        this.xp = xp;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof XP // instanceof handles nulls
+                && xp.equals(((XP) other).xp)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return xp.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/achievement/XP.java
+++ b/src/main/java/seedu/address/model/achievement/XP.java
@@ -1,14 +1,17 @@
 package seedu.address.model.achievement;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents the experience point(xp) earned by the user while using the task manager.
+ * Guarantees: xp value is immutable and valid as declared in {@link #isValidXP(Integer)}
  */
 public class XP {
     
     public static final String MESSAGE_XP_CONSTRAINTS =
-            "XP should have integer values.";
+            "XP should have positive integer values.";
+    public static final String XP_VALIDATION_REGEX = "^[1-9][0-9]*$";
     private final Integer xp;
 
     /**
@@ -25,7 +28,15 @@ public class XP {
      */
     public XP(Integer xp) {
         requireNonNull(xp);
+        checkArgument(isValidXP(xp), MESSAGE_XP_CONSTRAINTS);
         this.xp = xp;
+    }
+
+    /**
+     * Returns true if a given integer is a valid xp.
+     */
+    public static boolean isValidXP(Integer test) {
+        return test.toString().matches(XP_VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/achievement/XP.java
+++ b/src/main/java/seedu/address/model/achievement/XP.java
@@ -11,7 +11,6 @@ public class XP {
     
     public static final String MESSAGE_XP_CONSTRAINTS =
             "XP should have positive integer values.";
-    public static final String XP_VALIDATION_REGEX = "^[1-9][0-9]*$";
     private final Integer xp;
 
     /**
@@ -33,10 +32,18 @@ public class XP {
     }
 
     /**
+     * Getter of the xp value.
+     * @return xp
+     */
+    public Integer getXp() {
+        return this.xp;
+    }
+
+    /**
      * Returns true if a given integer is a valid xp.
      */
     public static boolean isValidXP(Integer test) {
-        return test.toString().matches(XP_VALIDATION_REGEX);
+        return test instanceof Integer && test >= 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/achievement/Xp.java
+++ b/src/main/java/seedu/address/model/achievement/Xp.java
@@ -5,36 +5,32 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents the experience point(xp) earned by the user while using the task manager.
- * Guarantees: xp value is immutable and valid as declared in {@link #isValidXP(Integer)}
+ * Guarantees: xp value is immutable and valid as declared in {@link #isValidXp(Integer)}
  */
-public class XP {
-    
+public class Xp {
+
     public static final String MESSAGE_XP_CONSTRAINTS =
-            "XP should have positive integer values.";
+            "Xp should have positive integer values.";
     private final Integer xp;
 
     /**
-     * Constructs an XP of value 0.
+     * Constructs an Xp of value 0.
      */
-    public XP() {
+    public Xp() {
         this.xp = 0;
     }
 
     /**
-     * Constructs a {@code XP}.
+     * Constructs a {@code Xp}.
      *
      * @param xp A valid xp value.
      */
-    public XP(Integer xp) {
+    public Xp(Integer xp) {
         requireNonNull(xp);
-        checkArgument(isValidXP(xp), MESSAGE_XP_CONSTRAINTS);
+        checkArgument(isValidXp(xp), MESSAGE_XP_CONSTRAINTS);
         this.xp = xp;
     }
 
-    /**
-     * Getter of the xp value.
-     * @return xp
-     */
     public Integer getXp() {
         return this.xp;
     }
@@ -42,15 +38,15 @@ public class XP {
     /**
      * Returns true if a given integer is a valid xp.
      */
-    public static boolean isValidXP(Integer test) {
+    public static boolean isValidXp(Integer test) {
         return test instanceof Integer && test >= 0;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof XP // instanceof handles nulls
-                && xp.equals(((XP) other).xp)); // state check
+                || (other instanceof Xp // instanceof handles nulls
+                && xp.equals(((Xp) other).xp)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Status.java
+++ b/src/main/java/seedu/address/model/task/Status.java
@@ -2,26 +2,26 @@ package seedu.address.model.task;
 
 /**
  * Represents a Task's status in the task manager.
- * There are two possible status: IN_PROGRESS and COMPLETED.
+ * There are three possible status: IN_PROGRESS, COMPLETED and OVERDUE.
  */
 public enum Status {
     IN_PROGRESS("IN PROGRESS"), COMPLETED("COMPLETED"), OVERDUE("OVERDUE");
 
     public static final String MESSAGE_STATUS_CONSTRAINTS =
             "Status should only have the value IN PROGRESS, COMPLETED or OVERDUE";
-    private String statusValue;
+    private String statusName;
 
     /**
      * Constructs a {@code Status}.
      *
-     * @param statusValue A valid statusValue.
+     * @param statusName A valid statusName.
      */
-    Status(String statusValue) {
-        this.statusValue = statusValue;
+    Status(String statusName) {
+        this.statusName = statusName;
     }
 
     /**
-     * Returns true if a given string is a valid Status value.
+     * Returns true if a given string is a valid Status name.
      */
     public static boolean isValidStatus(String value) {
         try {
@@ -32,17 +32,17 @@ public enum Status {
     }
 
     /**
-     * Returns the corresponding status object of {@param value}.
+     * Returns the corresponding status object of {@param name}.
      */
-    public static Status getStatusFromValue(String value) {
-        if (!isValidStatus(value)) {
+    public static Status fromString(String name) {
+        if (!isValidStatus(name)) {
             throw new IllegalArgumentException();
         }
-        return value.equals("IN PROGRESS") ? Status.IN_PROGRESS : Status.valueOf(value);
+        return name.equals("IN PROGRESS") ? Status.IN_PROGRESS : Status.valueOf(name);
     }
 
     @Override
     public String toString() {
-        return statusValue;
+        return statusName;
     }
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -73,9 +73,9 @@ public class StorageManager extends ComponentManager implements Storage {
     }
 
     @Override
-    public void saveTaskManager(ReadOnlyTaskManager addressBook, Path filePath) throws IOException {
+    public void saveTaskManager(ReadOnlyTaskManager taskManager, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
-        addressBookStorage.saveTaskManager(addressBook, filePath);
+        addressBookStorage.saveTaskManager(taskManager, filePath);
     }
 
 

--- a/src/main/java/seedu/address/storage/XMLAdaptedAchievementRecord.java
+++ b/src/main/java/seedu/address/storage/XMLAdaptedAchievementRecord.java
@@ -38,7 +38,7 @@ public class XMLAdaptedAchievementRecord {
     public XMLAdaptedAchievementRecord(AchievementRecord source) {
         requireNonNull(source);
         
-        xp = source.getXp().toString();
+        xp = source.getXp().getXp().toString();
         level = source.getLevel().toString();
     }
 

--- a/src/main/java/seedu/address/storage/XMLAdaptedAchievementRecord.java
+++ b/src/main/java/seedu/address/storage/XMLAdaptedAchievementRecord.java
@@ -1,0 +1,101 @@
+package seedu.address.storage;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.achievement.AchievementRecord;
+import seedu.address.model.achievement.Level;
+import seedu.address.model.achievement.XP;
+
+/**
+ * JAXB-friendly version of the {@code AchievementRecord}.
+ */
+public class XMLAdaptedAchievementRecord {
+    
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Achievement record's %s field is missing!";
+    
+    @XmlElement(required = true)
+    private String xp;
+    @XmlElement(required = true)
+    private String level;
+
+    /**
+     * Constructs an {@code XmlAdaptedAchievementRecord}.
+     * This is the no-arg constructor that is required by JAXB.
+     */
+    public XMLAdaptedAchievementRecord() {}
+
+    /**
+     * Converts a given AchievementRecord into this class for JAXB use.
+     *
+     * @param source future changes to this will not affect the created {@code XmlAdaptedAchievementRecord}.
+     */
+    public XMLAdaptedAchievementRecord(AchievementRecord source) {
+        requireNonNull(source);
+        
+        xp = source.getXp().toString();
+        level = source.getLevel().toString();
+    }
+
+    /**
+     * Constructs an {@code XmlAdaptedAchievementRecord} with the given achievement details.
+     */
+    public XMLAdaptedAchievementRecord(String xp, String level) {
+        requireAllNonNull(xp, level);
+        
+        this.xp = xp;
+        this.level = level;
+    }
+
+    /**
+     * Converts this jaxb-friendly {@code XmlAdaptedAchievementRecord} object into the model's 
+     * {@code AchievementRecord} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted achievement record.
+     */
+    public AchievementRecord toModelType() throws IllegalValueException {
+        if (xp == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, XP.class.getSimpleName()));
+        }
+        Integer xpValue;
+        try {
+            xpValue = Integer.valueOf(xp);
+        } catch(NumberFormatException nfex) {
+            throw new IllegalValueException(XP.MESSAGE_XP_CONSTRAINTS);
+        }
+        if (!XP.isValidXP(xpValue)) {
+            throw new IllegalValueException(XP.MESSAGE_XP_CONSTRAINTS);
+        }
+        final XP modelXP = new XP(xpValue);
+
+        if (level == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Level.class.getSimpleName()));
+        }
+        if (!Level.isValidLevel(level)) {
+            throw new IllegalValueException(Level.MESSAGE_LEVEL_CONSTRAINTS);
+        }
+        final Level modelLevel = Level.fromString(level);
+        
+        return new AchievementRecord(modelXP, modelLevel);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XMLAdaptedAchievementRecord)) {
+            return false;
+        }
+
+        XMLAdaptedAchievementRecord otherRecord = (XMLAdaptedAchievementRecord) other;
+        return Objects.equals(xp, otherRecord.xp)
+                && Objects.equals(level, otherRecord.level);
+    }
+}

--- a/src/main/java/seedu/address/storage/XmlAdaptedAchievementRecord.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedAchievementRecord.java
@@ -10,15 +10,15 @@ import javax.xml.bind.annotation.XmlElement;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.achievement.AchievementRecord;
 import seedu.address.model.achievement.Level;
-import seedu.address.model.achievement.XP;
+import seedu.address.model.achievement.Xp;
 
 /**
  * JAXB-friendly version of the {@code AchievementRecord}.
  */
-public class XMLAdaptedAchievementRecord {
-    
+public class XmlAdaptedAchievementRecord {
+
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Achievement record's %s field is missing!";
-    
+
     @XmlElement(required = true)
     private String xp;
     @XmlElement(required = true)
@@ -28,16 +28,16 @@ public class XMLAdaptedAchievementRecord {
      * Constructs an {@code XmlAdaptedAchievementRecord}.
      * This is the no-arg constructor that is required by JAXB.
      */
-    public XMLAdaptedAchievementRecord() {}
+    public XmlAdaptedAchievementRecord() {}
 
     /**
      * Converts a given AchievementRecord into this class for JAXB use.
      *
      * @param source future changes to this will not affect the created {@code XmlAdaptedAchievementRecord}.
      */
-    public XMLAdaptedAchievementRecord(AchievementRecord source) {
+    public XmlAdaptedAchievementRecord(AchievementRecord source) {
         requireNonNull(source);
-        
+
         xp = source.getXp().getXp().toString();
         level = source.getLevel().toString();
     }
@@ -45,33 +45,33 @@ public class XMLAdaptedAchievementRecord {
     /**
      * Constructs an {@code XmlAdaptedAchievementRecord} with the given achievement details.
      */
-    public XMLAdaptedAchievementRecord(String xp, String level) {
+    public XmlAdaptedAchievementRecord(String xp, String level) {
         requireAllNonNull(xp, level);
-        
+
         this.xp = xp;
         this.level = level;
     }
 
     /**
-     * Converts this jaxb-friendly {@code XmlAdaptedAchievementRecord} object into the model's 
+     * Converts this jaxb-friendly {@code XmlAdaptedAchievementRecord} object into the model's
      * {@code AchievementRecord} object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted achievement record.
      */
     public AchievementRecord toModelType() throws IllegalValueException {
         if (xp == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, XP.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Xp.class.getSimpleName()));
         }
         Integer xpValue;
         try {
             xpValue = Integer.valueOf(xp);
-        } catch(NumberFormatException nfex) {
-            throw new IllegalValueException(XP.MESSAGE_XP_CONSTRAINTS);
+        } catch (NumberFormatException nfex) {
+            throw new IllegalValueException(Xp.MESSAGE_XP_CONSTRAINTS);
         }
-        if (!XP.isValidXP(xpValue)) {
-            throw new IllegalValueException(XP.MESSAGE_XP_CONSTRAINTS);
+        if (!Xp.isValidXp(xpValue)) {
+            throw new IllegalValueException(Xp.MESSAGE_XP_CONSTRAINTS);
         }
-        final XP modelXP = new XP(xpValue);
+        final Xp modelXp = new Xp(xpValue);
 
         if (level == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Level.class.getSimpleName()));
@@ -80,8 +80,8 @@ public class XMLAdaptedAchievementRecord {
             throw new IllegalValueException(Level.MESSAGE_LEVEL_CONSTRAINTS);
         }
         final Level modelLevel = Level.fromString(level);
-        
-        return new AchievementRecord(modelXP, modelLevel);
+
+        return new AchievementRecord(modelXp, modelLevel);
     }
 
     @Override
@@ -90,11 +90,11 @@ public class XMLAdaptedAchievementRecord {
             return true;
         }
 
-        if (!(other instanceof XMLAdaptedAchievementRecord)) {
+        if (!(other instanceof XmlAdaptedAchievementRecord)) {
             return false;
         }
 
-        XMLAdaptedAchievementRecord otherRecord = (XMLAdaptedAchievementRecord) other;
+        XmlAdaptedAchievementRecord otherRecord = (XmlAdaptedAchievementRecord) other;
         return Objects.equals(xp, otherRecord.xp)
                 && Objects.equals(level, otherRecord.level);
     }

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -140,7 +140,7 @@ public class XmlAdaptedTask {
         if (!Status.isValidStatus(status)) {
             throw new IllegalValueException(Status.MESSAGE_STATUS_CONSTRAINTS);
         }
-        final Status modelStatus = Status.getStatusFromValue(status);
+        final Status modelStatus = Status.fromString(status);
         return new Task(modelName, modelDueDate, modelPriorityValue, modelDescription, modelLabels, modelStatus);
     }
 

--- a/src/main/java/seedu/address/storage/XmlSerializableTaskManager.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableTaskManager.java
@@ -21,6 +21,8 @@ public class XmlSerializableTaskManager {
     public static final String MESSAGE_DUPLICATE_TASK = "Tasks list contains duplicate task(s).";
 
     @XmlElement
+    private XMLAdaptedAchievementRecord achievements;
+    @XmlElement
     private List<XmlAdaptedTask> tasks;
 
     /**
@@ -28,6 +30,7 @@ public class XmlSerializableTaskManager {
      * This empty constructor is required for marshalling.
      */
     public XmlSerializableTaskManager() {
+        achievements = new XMLAdaptedAchievementRecord();
         tasks = new ArrayList<>();
     }
 
@@ -36,6 +39,7 @@ public class XmlSerializableTaskManager {
      */
     public XmlSerializableTaskManager(ReadOnlyTaskManager src) {
         this();
+        achievements = new XMLAdaptedAchievementRecord(src.getAchievementRecord().get());
         tasks.addAll(src.getTaskList().stream().map(XmlAdaptedTask::new).collect(Collectors.toList()));
     }
 
@@ -54,6 +58,7 @@ public class XmlSerializableTaskManager {
             }
             taskManager.addTask(task);
         }
+        taskManager.setAchievements(achievements.toModelType());
         return taskManager;
     }
 
@@ -66,6 +71,7 @@ public class XmlSerializableTaskManager {
         if (!(other instanceof XmlSerializableTaskManager)) {
             return false;
         }
-        return tasks.equals(((XmlSerializableTaskManager) other).tasks);
+        return tasks.equals(((XmlSerializableTaskManager) other).tasks)
+                && achievements.equals(((XmlSerializableTaskManager) other).achievements);
     }
 }

--- a/src/main/java/seedu/address/storage/XmlSerializableTaskManager.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableTaskManager.java
@@ -21,7 +21,7 @@ public class XmlSerializableTaskManager {
     public static final String MESSAGE_DUPLICATE_TASK = "Tasks list contains duplicate task(s).";
 
     @XmlElement
-    private XMLAdaptedAchievementRecord achievements;
+    private XmlAdaptedAchievementRecord achievements;
     @XmlElement
     private List<XmlAdaptedTask> tasks;
 
@@ -30,7 +30,7 @@ public class XmlSerializableTaskManager {
      * This empty constructor is required for marshalling.
      */
     public XmlSerializableTaskManager() {
-        achievements = new XMLAdaptedAchievementRecord();
+        achievements = new XmlAdaptedAchievementRecord();
         tasks = new ArrayList<>();
     }
 
@@ -39,7 +39,7 @@ public class XmlSerializableTaskManager {
      */
     public XmlSerializableTaskManager(ReadOnlyTaskManager src) {
         this();
-        achievements = new XMLAdaptedAchievementRecord(src.getAchievementRecord().get());
+        achievements = new XmlAdaptedAchievementRecord(src.getAchievementRecord().get());
         tasks.addAll(src.getTaskList().stream().map(XmlAdaptedTask::new).collect(Collectors.toList()));
     }
 

--- a/src/test/data/XmlSerializableTaskManagerTest/duplicateTaskTaskManager.xml
+++ b/src/test/data/XmlSerializableTaskManagerTest/duplicateTaskTaskManager.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <taskmanager>
-
+    <achievements>
+        <xp>0</xp>
+        <level>lvl.1</level>
+    </achievements>
     <tasks>
         <name>Address CS2103 email</name>
         <dueDate>01-12-18</dueDate>

--- a/src/test/data/XmlSerializableTaskManagerTest/invalidTaskManager.xml
+++ b/src/test/data/XmlSerializableTaskManagerTest/invalidTaskManager.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <taskmanager>
     <!-- Person with invalid priorityValue field -->
+    <achievements>
+        <xp>0</xp>
+        <level>lvl.1</level>
+    </achievements>
     <tasks>
         <name>Hans Muster</name>
         <dueDate isPrivate="false">21-12-18</dueDate>

--- a/src/test/data/XmlSerializableTaskManagerTest/typicalTasksTaskManager.xml
+++ b/src/test/data/XmlSerializableTaskManagerTest/typicalTasksTaskManager.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- TaskManager save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook() -->
 <taskmanager>
+    <achievements>
+        <xp>0</xp>
+        <level>lvl.1</level>
+    </achievements>
     <tasks>
         <name>Address CS2103 email</name>
         <dueDate>01-12-18</dueDate>

--- a/src/test/data/XmlTaskManagerStorageTest/invalidAndValidTaskTaskManager.xml
+++ b/src/test/data/XmlTaskManagerStorageTest/invalidAndValidTaskTaskManager.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <taskmanager>
     <!-- Valid Task -->
+    <achievements>
+        <xp>0</xp>
+        <level>lvl.1</level>
+    </achievements>
     <tasks>
         <name>Hans Muster</name>
         <dueDate isPrivate="false">21-12-18</dueDate>

--- a/src/test/data/XmlTaskManagerStorageTest/invalidTaskManager.xml
+++ b/src/test/data/XmlTaskManagerStorageTest/invalidTaskManager.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <taskmanager>
     <!-- Task with invalid name field -->
+    <achievements>
+        <xp>0</xp>
+        <level>lvl.1</level>
+    </achievements>
     <tasks>
         <name>Ha!ns Mu@ster</name>
         <dueDate isPrivate="false">21-12-18</dueDate>

--- a/src/test/data/XmlUtilTest/validTaskManager.xml
+++ b/src/test/data/XmlUtilTest/validTaskManager.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <taskmanager>
+    <achievements>
+        <xp>0</xp>
+        <level>lvl.1</level>
+    </achievements>
     <tasks>
         <name>Hans Muster</name>
         <dueDate isPrivate="false">21-12-18</dueDate>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -130,6 +130,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateTaskStatus(Task target, Task updatedTask) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Task> getFilteredTaskList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -294,7 +294,7 @@ public class CompleteCommandTest {
             .forEach(pairOfTasks -> {
                 Task taskToComplete = pairOfTasks.getKey();
                 Task completedTask = pairOfTasks.getValue();
-                expectedModel.updateTask(taskToComplete, completedTask);
+                expectedModel.updateTaskStatus(taskToComplete, completedTask);
                 completedTasksOutput.append(completedTask.toString() + "\n");
             });
 

--- a/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CompleteCommandTest.java
@@ -40,7 +40,7 @@ public class CompleteCommandTest {
         String expectedMessage = String.format(CompleteCommand.MESSAGE_SUCCESS, completedTask);
 
         ModelManager expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
-        expectedModel.updateTask(taskToComplete, completedTask);
+        expectedModel.updateTaskStatus(taskToComplete, completedTask);
         expectedModel.commitTaskManager();
 
         assertCommandSuccess(completeCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -65,7 +65,7 @@ public class CompleteCommandTest {
         String expectedMessage = String.format(CompleteCommand.MESSAGE_SUCCESS, completedTask);
 
         Model expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
-        expectedModel.updateTask(taskToComplete, completedTask);
+        expectedModel.updateTaskStatus(taskToComplete, completedTask);
         expectedModel.commitTaskManager();
 
         assertCommandSuccess(completeCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -89,7 +89,7 @@ public class CompleteCommandTest {
         Task taskToComplete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
         CompleteCommand completeCommand = new CompleteCommand(INDEX_FIRST_TASK);
         Model expectedModel = new ModelManager(model.getTaskManager(), new UserPrefs());
-        expectedModel.updateTask(taskToComplete, simpleCompleteTask(taskToComplete));
+        expectedModel.updateTaskStatus(taskToComplete, simpleCompleteTask(taskToComplete));
         expectedModel.commitTaskManager();
 
         // complete -> first task completed
@@ -133,7 +133,7 @@ public class CompleteCommandTest {
 
         showTaskAtIndex(model, INDEX_SECOND_TASK);
         Task taskToComplete = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
-        expectedModel.updateTask(taskToComplete, simpleCompleteTask(taskToComplete));
+        expectedModel.updateTaskStatus(taskToComplete, simpleCompleteTask(taskToComplete));
         expectedModel.commitTaskManager();
 
         // completes -> completes second task in unfiltered task list / first task in filtered task

--- a/src/test/java/seedu/address/model/TaskManagerTest.java
+++ b/src/test/java/seedu/address/model/TaskManagerTest.java
@@ -17,8 +17,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.achievement.AchievementRecord;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.exceptions.DuplicateTaskException;
 import seedu.address.testutil.TaskBuilder;
@@ -106,6 +108,11 @@ public class TaskManagerTest {
         @Override
         public ObservableList<Task> getTaskList() {
             return tasks;
+        }
+        
+        @Override
+        public SimpleObjectProperty<AchievementRecord> getAchievementRecord() {
+            throw new AssertionError("This method should not be called.");
         }
     }
 

--- a/src/test/java/seedu/address/model/TaskManagerTest.java
+++ b/src/test/java/seedu/address/model/TaskManagerTest.java
@@ -109,7 +109,7 @@ public class TaskManagerTest {
         public ObservableList<Task> getTaskList() {
             return tasks;
         }
-        
+
         @Override
         public SimpleObjectProperty<AchievementRecord> getAchievementRecord() {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/model/task/StatusTest.java
+++ b/src/test/java/seedu/address/model/task/StatusTest.java
@@ -34,15 +34,15 @@ public class StatusTest {
     }
 
     @Test
-    public void getStatusFromValue() {
+    public void fromString() {
         //invalid status value
-        Assert.assertThrows(IllegalArgumentException.class, () -> Status.getStatusFromValue("in progress"));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Status.getStatusFromValue("hello"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> Status.fromString("in progress"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> Status.fromString("hello"));
 
         //valid status value
-        assertEquals(Status.getStatusFromValue("IN PROGRESS"), Status.IN_PROGRESS);
-        assertEquals(Status.getStatusFromValue("COMPLETED"), Status.COMPLETED);
-        assertEquals(Status.getStatusFromValue("OVERDUE"), Status.OVERDUE);
+        assertEquals(Status.fromString("IN PROGRESS"), Status.IN_PROGRESS);
+        assertEquals(Status.fromString("COMPLETED"), Status.COMPLETED);
+        assertEquals(Status.fromString("OVERDUE"), Status.OVERDUE);
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/TaskListPanelTest.java
+++ b/src/test/java/seedu/address/ui/TaskListPanelTest.java
@@ -94,6 +94,10 @@ public class TaskListPanelTest extends GuiUnitTest {
         StringBuilder builder = new StringBuilder();
         builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
         builder.append("<taskmanager>\n");
+        builder.append("<achievements>\n");
+        builder.append("<xp>0</xp>\n");
+        builder.append("<level>lvl.1</level>\n");
+        builder.append("</achievements>\n");
         for (int i = 0; i < taskCount; i++) {
             builder.append("<tasks>\n");
             builder.append("<name>").append(i).append("a</name>\n");


### PR DESCRIPTION
Change Log
---
fix #83 
fix #82 
* Add an achievements field (of class AchievementRecord) to TaskManager in addition to the existing tasks field.
* AchievementRecord has an xp field (of class Xp) and a level field (of enum Level).
* When xp is updated, level is re-calculated and updated accordingly.
* Add updateTaskStatus method in ModelManager which is called by CompleteCommand when a task is marked as complete. UpdateTaskStatus calls for the update of the user's xp and level.
* Currently the xp for completing each task is set at 50.
* Add XmlAdaptedAchievementRecord to XmlSerializableTaskManager for storage of achievements in XML file.
* Operations on task are not affected.
* This PR does not contain tests for the new fields/methods added.