### PR TITLE
Add "today" filter for list

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -77,7 +77,23 @@ Format:
 [%hardbreaks]
 Shows a list of all tasks.
 
-+Example: `list`
+Format:
+`list [b/DUE_BEFORE]`, where DUE_BEFORE must be any of the following:
+
+ * `today`
+
+ * `week`
+
+ * `month`
+
++Example:
+`list`
+
++Example:
+`list b/today`
+
+-Example:
+`list b/alltime`
 ```
 1. finish math tutorial  DueDate: 01-10-18 1300 Description: before exam PriorityValue: 2 Status: IN PROGRESS
 2. Attack Food  DueDate: 01-10-18 Description: what did food do PriorityValue: 88 Status: FINISHED

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -41,7 +41,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        model.updateFilteredTaskList(this.predicate);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 import java.util.function.Predicate;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
+import seedu.address.model.task.DueDateIsBeforeTodayPredicate;
 import seedu.address.model.task.Task;
 
 /**
@@ -28,10 +29,10 @@ public class ListCommand extends Command {
     public ListCommand(ListFilter listFilter) {
         switch (listFilter) {
             case DUE_TODAY:
-                this.predicate = PREDICATE_SHOW_ALL_TASKS;
+                this.predicate = new DueDateIsBeforeTodayPredicate();
                 break;
             default:
-                this.predicate = null;
+                this.predicate = PREDICATE_SHOW_ALL_TASKS;
                 break;
         }
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.ListCommandParser.PREFIX_DUE_BEFORE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.function.Predicate;
@@ -19,6 +20,12 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all tasks";
 
     private final Predicate<Task> predicate;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists tasks. "
+            + "Parameters: "
+            + "[" + PREFIX_DUE_BEFORE + "DUE BEFORE " + "]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_DUE_BEFORE + "today";
 
     public enum ListFilter {
             DUE_TODAY;

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,8 +3,10 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
+import java.util.function.Predicate;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
+import seedu.address.model.task.Task;
 
 /**
  * Lists all tasks in the task manager to the user.
@@ -14,6 +16,25 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all tasks";
+
+    private final Predicate<Task> predicate;
+
+    public enum ListFilter {
+            DUE_TODAY;
+    }
+
+    public ListCommand() { this.predicate = PREDICATE_SHOW_ALL_TASKS; }
+
+    public ListCommand(ListFilter listFilter) {
+        switch (listFilter) {
+            case DUE_TODAY:
+                this.predicate = PREDICATE_SHOW_ALL_TASKS;
+                break;
+            default:
+                this.predicate = null;
+                break;
+        }
+    }
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,11 +5,14 @@ import static seedu.address.logic.parser.ListCommandParser.PREFIX_DUE_BEFORE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.task.DueDateIsBeforeTodayPredicate;
 import seedu.address.model.task.Task;
+
+
 
 /**
  * Lists all tasks in the task manager to the user.
@@ -20,28 +23,34 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all tasks";
 
-    private final Predicate<Task> predicate;
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists tasks. "
             + "Parameters: "
             + "[" + PREFIX_DUE_BEFORE + "DUE BEFORE " + "]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DUE_BEFORE + "today";
 
+    private final Predicate<Task> predicate;
+
+    /**
+     * Denotes the kind of filters List supports.
+     */
     public enum ListFilter {
             DUE_TODAY;
     }
 
-    public ListCommand() { this.predicate = PREDICATE_SHOW_ALL_TASKS; }
+    public ListCommand() {
+        this.predicate = PREDICATE_SHOW_ALL_TASKS;
+    }
 
     public ListCommand(ListFilter listFilter) {
         switch (listFilter) {
-            case DUE_TODAY:
-                this.predicate = new DueDateIsBeforeTodayPredicate();
-                break;
-            default:
-                this.predicate = PREDICATE_SHOW_ALL_TASKS;
-                break;
+        case DUE_TODAY:
+            this.predicate = new DueDateIsBeforeTodayPredicate();
+            break;
+
+        default:
+            this.predicate = PREDICATE_SHOW_ALL_TASKS;
+            break;
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.ListCommandParser.PREFIX_DUE_BEFORE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.function.Predicate;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.task.DueDateIsBeforeTodayPredicate;
@@ -49,6 +50,9 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
         model.updateFilteredTaskList(this.predicate);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return model.getFilteredTaskList().size() == model.getTaskManager().getTaskList().size()
+                ? new CommandResult(MESSAGE_SUCCESS)
+                : new CommandResult(String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW,
+                    model.getFilteredTaskList().size()));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -75,7 +75,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand().parse(arguments);
+            return new ListCommandParser().parse(arguments);
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -75,7 +75,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommand().parse(arguments);
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -28,14 +28,14 @@ public class ListCommandParser implements Parser<ListCommand> {
 
     private static Prefix PREFIX_DUE_BEFORE = new Prefix("b/");
 
-    private Optional<ListCommand.ListFilter> parseListFilter(Optional<String> s) {
+    private Optional<ListCommand.ListFilter> parseListFilter(Optional<String> s)throws ParseException {
         if (s.isPresent()) {
             String val = s.get();
             switch (val) {
                 case "today":
                     return Optional.of(ListCommand.ListFilter.DUE_TODAY);
                 default:
-                    return Optional.empty();
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Walk it like I talk it"));
             }
         } else {
             return Optional.empty();
@@ -52,25 +52,10 @@ public class ListCommandParser implements Parser<ListCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_DUE_BEFORE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_DUE_BEFORE)
-                || !argMultimap.getPreamble().isEmpty()) {
-          // TODO
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Walk it like I talk it"));
-        }
-
         Optional<ListCommand.ListFilter> listFilter = parseListFilter(argMultimap.getValue(PREFIX_DUE_BEFORE));
 
         return listFilter
                 .flatMap(filter -> Optional.of(new ListCommand(filter)))
                 .orElseGet(() -> new ListCommand());
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DUE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_VALUE;
+import java.lang.management.OperatingSystemMXBean;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.swing.text.html.Option;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Label;
+import seedu.address.model.task.Description;
+import seedu.address.model.task.DueDate;
+import seedu.address.model.task.Name;
+import seedu.address.model.task.PriorityValue;
+import seedu.address.model.task.Task;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    private static Prefix PREFIX_DUE_BEFORE = new Prefix("b/");
+
+    private Optional<ListCommand.ListFilter> parseListFilter(Optional<String> s) {
+        if (s.isPresent()) {
+            String val = s.get();
+            switch (val) {
+                case "today":
+                    return Optional.of(ListCommand.ListFilter.DUE_TODAY);
+                default:
+                    return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns an FindCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DUE_BEFORE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_DUE_BEFORE)
+                || !argMultimap.getPreamble().isEmpty()) {
+          // TODO
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Walk it like I talk it"));
+        }
+
+        Optional<ListCommand.ListFilter> listFilter = parseListFilter(argMultimap.getValue(PREFIX_DUE_BEFORE));
+
+        return listFilter
+                .flatMap(filter -> Optional.of(new ListCommand(filter)))
+                .orElseGet(() -> new ListCommand());
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -26,7 +26,7 @@ import seedu.address.model.task.Task;
  */
 public class ListCommandParser implements Parser<ListCommand> {
 
-    private static Prefix PREFIX_DUE_BEFORE = new Prefix("b/");
+    public static Prefix PREFIX_DUE_BEFORE = new Prefix("b/");
 
     private Optional<ListCommand.ListFilter> parseListFilter(Optional<String> s)throws ParseException {
         if (s.isPresent()) {
@@ -35,7 +35,7 @@ public class ListCommandParser implements Parser<ListCommand> {
                 case "today":
                     return Optional.of(ListCommand.ListFilter.DUE_TODAY);
                 default:
-                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Walk it like I talk it"));
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
             }
         } else {
             return Optional.empty();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,41 +1,37 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DUE_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_VALUE;
-import java.lang.management.OperatingSystemMXBean;
+
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
-import javax.swing.text.html.Option;
-import seedu.address.logic.commands.AddCommand;
+
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Label;
-import seedu.address.model.task.Description;
-import seedu.address.model.task.DueDate;
-import seedu.address.model.task.Name;
-import seedu.address.model.task.PriorityValue;
-import seedu.address.model.task.Task;
+
 
 /**
  * Parses input arguments and creates a new ListCommand object
  */
 public class ListCommandParser implements Parser<ListCommand> {
 
-    public static Prefix PREFIX_DUE_BEFORE = new Prefix("b/");
+    /** Used to get the "due before" filter option */
+    public static final Prefix PREFIX_DUE_BEFORE = new Prefix("b/");
 
+    /**
+     * Parses a string that represents a list filter option.
+     *
+     * @param s the optional string the denotes the list filter type
+     * @return an Optional ListFilter, which is not present if there is no string parameter
+     * @throws ParseException if a list filter is present but the filter type is invalid
+     */
     private Optional<ListCommand.ListFilter> parseListFilter(Optional<String> s)throws ParseException {
         if (s.isPresent()) {
             String val = s.get();
             switch (val) {
-                case "today":
-                    return Optional.of(ListCommand.ListFilter.DUE_TODAY);
-                default:
-                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            case "today":
+                return Optional.of(ListCommand.ListFilter.DUE_TODAY);
+
+            default:
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
             }
         } else {
             return Optional.empty();

--- a/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
+++ b/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
@@ -1,0 +1,36 @@
+package seedu.address.model.task;
+
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.function.Predicate;
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Task}'s {@code DueDate} is before the end of today.
+ */
+public class DueDateIsBeforeTodayPredicate implements Predicate<Task> {
+
+    @Override
+    public boolean test(Task person) {
+        /** Get today's date, 2359 */
+        Calendar date = new GregorianCalendar();
+        date.set(Calendar.HOUR_OF_DAY, 23);
+        date.set(Calendar.MINUTE, 59);
+        date.set(Calendar.SECOND, 0);
+        date.set(Calendar.MILLISECOND, 0);
+
+        return person.getDueDate().valueDate.before(date.getTime());
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DueDateIsBeforeTodayPredicate; // instanceof handles nulls
+
+    }
+
+}

--- a/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
+++ b/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
@@ -29,7 +29,7 @@ public class DueDateIsBeforeTodayPredicate implements Predicate<Task> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof DueDateIsBeforeTodayPredicate; // instanceof handles nulls
+                || (other instanceof DueDateIsBeforeTodayPredicate); // instanceof handles nulls
 
     }
 

--- a/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
+++ b/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
@@ -19,14 +19,12 @@ public class DueDateIsBeforeTodayPredicate implements Predicate<Task> {
         date.set(Calendar.MILLISECOND, 0);
 
         return person.getDueDate().valueDate.before(date.getTime());
-
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DueDateIsBeforeTodayPredicate); // instanceof handles nulls
-
     }
 
 }

--- a/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
+++ b/src/main/java/seedu/address/model/task/DueDateIsBeforeTodayPredicate.java
@@ -1,12 +1,8 @@
 package seedu.address.model.task;
 
-import java.time.Instant;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.List;
 import java.util.function.Predicate;
-import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Task}'s {@code DueDate} is before the end of today.

--- a/src/main/java/seedu/address/model/util/DateFormatUtil.java
+++ b/src/main/java/seedu/address/model/util/DateFormatUtil.java
@@ -25,10 +25,10 @@ public class DateFormatUtil {
     public static Date parseDate(String date) {
         Date result = null;
         try {
-            if (isValidDateMinimalFormat(date)) {
-                result = FORMAT_MINIMAL.parse(date);
-            } else if (isValidDateStandardFormat(date)) {
+            if (isValidDateStandardFormat(date)) {
                 result = FORMAT_STANDARD.parse(date);
+            } else if (isValidDateMinimalFormat(date)) {
+                result = FORMAT_MINIMAL.parse(date);
             }
         } catch (Exception e) {
             result = null;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,17 +1,26 @@
 package seedu.address.logic.commands;
 
+import static junit.framework.TestCase.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalTasks.A_TASK;
+import static seedu.address.testutil.TypicalTasks.J_TASK;
+import static seedu.address.testutil.TypicalTasks.K_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskManager;
 
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.TaskManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.task.DueDateIsBeforeTodayPredicate;
+import seedu.address.testutil.TaskManagerBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -37,5 +46,27 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showTaskAtIndex(model, INDEX_FIRST_TASK);
         assertCommandSuccess(new ListCommand(), model, commandHistory, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listFiltered_beforeToday() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 1);
+        ListCommand.ListFilter filter = ListCommand.ListFilter.DUE_TODAY;
+        ListCommand command = new ListCommand(filter);
+
+        TaskManager manager = (new TaskManagerBuilder())
+                .withTask(J_TASK)
+                .withTask(K_TASK)
+                .build();
+        // Build new ModelManagers to handle temporal differences
+        ModelManager modelWithExtremeTemporalTasks =
+                new ModelManager(manager, new UserPrefs());
+        ModelManager expectedModelWithPastTask =
+                new ModelManager(modelWithExtremeTemporalTasks.getTaskManager(), new UserPrefs());
+        expectedModelWithPastTask.updateFilteredTaskList(new DueDateIsBeforeTodayPredicate());
+
+        assertCommandSuccess(command, modelWithExtremeTemporalTasks, commandHistory,
+                expectedMessage, expectedModelWithPastTask);
+        assertEquals(Arrays.asList(J_TASK), modelWithExtremeTemporalTasks.getFilteredTaskList());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
-import static seedu.address.testutil.TypicalTasks.A_TASK;
 import static seedu.address.testutil.TypicalTasks.J_TASK;
 import static seedu.address.testutil.TypicalTasks.K_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskManager;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalTasks.K_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskManager;
 
 import java.util.Arrays;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -52,6 +52,10 @@ public class TypicalTasks {
             .withPriorityValue("8").withDescription("Step 2) ??? Step 3) PROFIT!!!").build();
     public static final Task I_TASK = new TaskBuilder().withName("Investigate Murder").withDueDate("09-12-18")
             .withPriorityValue("9").withDescription("Destroy all evidence pointing to myself").build();
+    public static final Task J_TASK = new TaskBuilder().withName("Do O Levels").withDueDate("10-10-12")
+            .withPriorityValue("8").withDescription("Don't play MapleStory").build();
+    public static final Task K_TASK = new TaskBuilder().withName("Finish my 5th PhD").withDueDate("10-10-2050")
+            .withPriorityValue("9").withDescription("Don't play MapleStory 8").build();
 
     // Manually added - Task's details found in {@code CommandTestUtil}
     public static final Task Y_TASK = new TaskBuilder().withName(VALID_NAME_AMY).withDueDate(VALID_DUEDATE_AMY)


### PR DESCRIPTION
### Features
- `list` command takes in a `b/` argument to list all tasks due before today (semantics: `b/today` -> "due before today")
- Fixes #87 