### PR TITLE
Fix typo in getMatchingLevel

### DIFF
--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -91,11 +91,11 @@ public class AchievementRecord {
         if (xp < Level.LEVEL_1.getMaxXp()) {
             return Level.LEVEL_1;
         } else if (xp < Level.LEVEL_2.getMaxXp()) {
-            return level.LEVEL_2;
+            return Level.LEVEL_2;
         } else if (xp < Level.LEVEL_3.getMaxXp()) {
-            return level.LEVEL_3;
+            return Level.LEVEL_3;
         } else if (xp < Level.LEVEL_4.getMaxXp()) {
-            return level.LEVEL_4;
+            return Level.LEVEL_4;
         } else {
             return Level.LEVEL_5;
         }


### PR DESCRIPTION
Change Log
---
Fix typo in the getMatchingLevel method of AchievementRecord class.