### PR TITLE
Add documentation relating to time

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -357,6 +357,15 @@ FINE : Details that is not usually noteworthy but may be useful in debugging e.g
 ### 3.4. Configuration
 Certain properties of the application can be controlled (e.g App name, logging level) through the configuration file (default: config.json).
 
+### 3.5 List
+
+The functionality of the default `list` command is as expected (and documented), that is all tasks are listed.
+The date filters are dependent on the due date of the task, and the current date.
+
+The Current Date is retrieved using Java's `Calendar`, and is adjusted to be the end of the day, week, or month
+depending on the `ListCommand` 's option. A predicate is then created to check if a given `Task` is before this date.
+This predicate is passed as an argument to update filtered Tasks.
+
 ## 4. Documentation
 We use asciidoc for writing documentation.
 

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -363,7 +363,7 @@ Time is of key importance when dealing with the `TaskManager`. We implement and 
 date comparison. The precision of time for tasks is to the minute, that is the `AddCommand` can accept a `DueDate`
 accurate to the minute.
 
-### 3.5 List
+### 3.6 List
 
 The functionality of the default `list` command is as expected (and documented), that is all tasks are listed.
 The date filters are dependent on the due date of the task, and the current date.

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -357,6 +357,12 @@ FINE : Details that is not usually noteworthy but may be useful in debugging e.g
 ### 3.4. Configuration
 Certain properties of the application can be controlled (e.g App name, logging level) through the configuration file (default: config.json).
 
+### 3.5 Handling Date
+Time is of key importance when dealing with the `TaskManager`. We implement and represent time using the ubiquitous
+`Date` class in Java. The class `DueDate` internally uses the `Date` class, and harnesses built in capabilities such as
+date comparison. The precision of time for tasks is to the minute, that is the `AddCommand` can accept a `DueDate`
+accurate to the minute.
+
 ### 3.5 List
 
 The functionality of the default `list` command is as expected (and documented), that is all tasks are listed.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -41,7 +41,9 @@ Adds a task to the task manager.
 Format:
 
 `add n/TASK_NAME l/DUE_DATE t/PRIORITY_VALUE [d/detailed description] [l/LABEL]`
-Date Format: yyyy-mm-dd or yyyy-mm-dd hhmm
+
+Date Format: `yyyy-mm-dd` or `yyyy-mm-dd hhmm`. A missing `hhmm` field will cause time to
+be interpreted as the start of the day, i.e `00:00`.
 
 On task creation, the task's `INDEX` is shown as such:
 ```


### PR DESCRIPTION
- DeveloperGuide: Added a section on how we deal with dates
- DeveloperGuide: Added a `ListCommand` section to explain date filters
- UserGuide: Added a clarification for the "time" field for `AddCommand`