### PR TITLE
Add protection of time-based achievement fields against time travel

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -182,7 +182,7 @@ Format: `find KEYWORD`
 [%hardbreaks]
 Displays the cumulative achievements of a user across a specified time period on the GUI.
 Such achievements include current level, xp earned and number of tasks completed across that time period.
-Format: `achievements TIME_SPAN`, a valid TIME_SPAN may take the vale of `all-time`, `today`, or `this week`.
+Format: `achievements TIME_SPAN`, a valid `TIME_SPAN` may take the value of `all-time`, `today`, or `this week`.
 
 [%hardbreaks]
 +Example: `achievements all-time`
@@ -190,6 +190,11 @@ Format: `achievements TIME_SPAN`, a valid TIME_SPAN may take the vale of `all-ti
 +Example: `achievements this week`
 -Example: `achievements all time`
 -Example: `achievements TODAY`
+
+[TIP]
+Today and this week's achievements assume users do not time travel. +
+Once a day/week is passed, its achievements cannot be retrieved again by `achievements today/this week` if the user ever
+comes back from the future.
 
 == FAQ
 

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -268,7 +268,12 @@ public class AchievementRecord {
     private void checkDayBreakPoint() {
         Calendar date = new GregorianCalendar();
         if (date.before(nextDayBreakPoint)) {
-            return;
+
+            // check that current time is within one day before nextWeekBreakPoint
+            date.add(Calendar.DAY_OF_MONTH, 1);
+            if (date.after(nextDayBreakPoint)) {
+                return;
+            }
         }
         nextDayBreakPoint = null;
         setUpAchievementByDay();
@@ -282,7 +287,12 @@ public class AchievementRecord {
     private void checkWeekBreakPoint() {
         Calendar date = new GregorianCalendar();
         if (date.before(nextWeekBreakPoint)) {
-            return;
+
+            // check that current time is within one week before nextWeekBreakPoint
+            date.add(Calendar.DAY_OF_MONTH, 7);
+            if (date.after(nextWeekBreakPoint)) {
+                return;
+            }
         }
         nextWeekBreakPoint = null;
         setUpAchievementByWeek();


### PR DESCRIPTION
Change Log
---
* Guard against time traveling. 
* Specify that If a user ever "comes back from the future" after changing system time, this day/week's time-based achievement information would not be retained.