### PR TITLE
Amend Date Parser to solve date parsing bug

### DIFF
--- a/src/main/java/seedu/address/model/task/DueDate.java
+++ b/src/main/java/seedu/address/model/task/DueDate.java
@@ -18,7 +18,6 @@ public class DueDate {
                     + " dd-mm-yy, dd-mm-yyyy, dd-mm-yy HHmm, dd-mm-yyyy HHmm\n"
                     + "Note: 24h time format";
 
-    public static final String DUEDATE_REGEX = "\\d{1,2}-\\d{1,2}-\\d{2,4}( \\d{4})?";
     public final String value;
     public final Date valueDate;
 
@@ -40,12 +39,7 @@ public class DueDate {
      * @param test date to be checked
      */
     public static boolean isValidDueDate(String test) {
-        if (test == null) {
-            throw new NullPointerException();
-        }
-        if (!test.matches(DUEDATE_REGEX)) {
-            return false;
-        }
+        requireNonNull(test);
         return isValidDateFormat(test);
     }
 

--- a/src/main/java/seedu/address/model/util/DateFormatUtil.java
+++ b/src/main/java/seedu/address/model/util/DateFormatUtil.java
@@ -7,6 +7,9 @@ import java.util.Date;
 public class DateFormatUtil {
     public static final String DATE_FORMAT_MINIMAL = "dd-MM-yy";
     public static final String DATE_FORMAT_STANDARD = "dd-MM-yy HHmm";
+    public static final String DATE_FORMAT_MINIMAL_REGEX = "\\d{1,2}-\\d{1,2}-\\d{2,4}";
+    public static final String DATE_FORMAT_STANDARD_REGEX = "\\d{1,2}-\\d{1,2}-\\d{2,4} \\d{4}";
+
     public static final SimpleDateFormat FORMAT_MINIMAL;
     public static final SimpleDateFormat FORMAT_STANDARD;
 
@@ -44,16 +47,16 @@ public class DateFormatUtil {
      * @return true if is the correct format. False otherwise
      */
     public static boolean isValidDateFormat(String test) {
-        return isValidDateFormatFromTemplate(test, FORMAT_MINIMAL)
-                || isValidDateFormatFromTemplate(test, FORMAT_STANDARD);
+        return isValidDateMinimalFormat(test)
+                || isValidDateStandardFormat(test);
     }
 
     private static boolean isValidDateMinimalFormat(String test) {
-        return isValidDateFormatFromTemplate(test, FORMAT_MINIMAL);
+        return isValidDateFormatFromTemplate(test, FORMAT_MINIMAL, DATE_FORMAT_MINIMAL_REGEX);
     }
 
     private static boolean isValidDateStandardFormat(String test) {
-        return isValidDateFormatFromTemplate(test, FORMAT_STANDARD);
+        return isValidDateFormatFromTemplate(test, FORMAT_STANDARD, DATE_FORMAT_STANDARD_REGEX);
     }
 
     /**
@@ -63,13 +66,13 @@ public class DateFormatUtil {
      * @param format format to test string with
      * @return true if is the correct format. False otherwise
      */
-    private static boolean isValidDateFormatFromTemplate(String test, SimpleDateFormat format) {
+    private static boolean isValidDateFormatFromTemplate(String test, SimpleDateFormat format, String regex) {
         try {
             format.parse(test);
         } catch (Exception e) {
             return false;
         }
-        return true;
+        return test.matches(regex);
     }
 
     /**


### PR DESCRIPTION
Resolves #211, #180

Details of bug are in the issues tagged above. 

Allowed for stricter regex testing by shifting regex testing to DateParserUtil class, with regex testing for each format. 

Files modified:
src/main/java/seedu/address/model/task/DueDate.java
src/main/java/seedu/address/model/util/DateFormatUtil.java
