### PR TITLE
Add guards for integer overflow to AchievementRecord

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -335,7 +335,7 @@ comes back from the future.
 
 [TIP]
 If under the unlikely circumstances, the increased xp or number of tasks completed is expected to exceed 1000000000,
-these fields will no long be updated.
+these fields will no longer be updated.
 
 // end::achievements-usage[]
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -332,6 +332,11 @@ Format: `achievements TIME_SPAN`, a valid `TIME_SPAN` may take the value of `all
 Today and this week's achievements assume users do not time travel. +
 Once a day/week is passed, its achievements cannot be retrieved again by `achievements today/this week` if the user ever
 comes back from the future.
+
+[TIP]
+If under the unlikely circumstances, the increased xp or number of tasks completed is expected to exceed 1000000000,
+these fields will no long be updated.
+
 // end::achievements-usage[]
 
 // tag::gamemode-usage[]

--- a/src/main/java/seedu/address/model/achievement/AchievementRecord.java
+++ b/src/main/java/seedu/address/model/achievement/AchievementRecord.java
@@ -24,6 +24,8 @@ import seedu.address.model.achievement.exceptions.XpLevelMismatchException;
  */
 public class AchievementRecord {
 
+    public static final int MAX_INT_VALUE = 1000000000;
+
     public static final int DISPLAY_ALL_TIME = 1;
     public static final int DISPLAY_TODAY = 2;
     public static final int DISPLAY_THIS_WEEK = 3;
@@ -328,9 +330,22 @@ public class AchievementRecord {
     /**
      * Increments the xp, numTaskCompleted fields of this {@code AchievementRecord} with the new xp value.
      * Recalculates level with the new xp value and increments if necessary.
+     *
+     * If the updated number of tasks completed or xp value excess the {@code MAX_INT_VALUE}, the fields are not updated
+     * anymore.
      */
     private void incrementAllTimeAchievementWithNewXp(int newXp) {
+        // one task is completed each time xp is awarded
+        int newNumTaskCompleted = numTaskCompleted + 1;
+        if (newNumTaskCompleted > MAX_INT_VALUE) {
+            return;
+        }
+        numTaskCompleted = newNumTaskCompleted;
+
         int updatedXpValue = this.getXpValue() + newXp;
+        if (updatedXpValue > MAX_INT_VALUE) {
+            return;
+        }
         this.xp = new Xp(updatedXpValue);
 
         // recalculate level based on updated xp and update level field if necessary
@@ -338,33 +353,54 @@ public class AchievementRecord {
         if (!this.level.equals(newLevel)) {
             level = newLevel;
         }
-
-        // one task is completed each time xp is awarded
-        numTaskCompleted++;
     }
 
     /**
      * Check if the current time has passed the previously set {@code nextDayBreakPoint}
      * Increment xp and number of tasks completed.
+     *
+     * If the updated number of tasks completed or xp value excess the {@code MAX_INT_VALUE}, the fields are not updated
+     * anymore.
      */
     private void incrementAchievementByDayWithNewXp(int newXp) {
         checkDayBreakPoint();
 
         // one task is completed each time xp is awarded
-        numTaskCompletedByDay++;
-        xpValueByDay += newXp;
+        int newNumTaskCompletedByDay = numTaskCompletedByDay + 1;
+        if (newNumTaskCompletedByDay > MAX_INT_VALUE) {
+            return;
+        }
+        numTaskCompletedByDay = newNumTaskCompletedByDay;
+
+        int updatedXpValueByDay = xpValueByDay + newXp;
+        if (updatedXpValueByDay > MAX_INT_VALUE) {
+            return;
+        }
+        xpValueByDay = updatedXpValueByDay;
     }
 
     /**
      * Check if the current time has passed the previously set {@code nextWeekBreakPoint}
      * Increment xp and number of tasks completed.
+     *
+     * If the updated number of tasks completed or xp value excess the {@code MAX_INT_VALUE}, the fields are not updated
+     * anymore.
      */
     private void incrementAchievementByWeekWithNewXp(int newXp) {
         checkWeekBreakPoint();
 
         // one task is completed each time xp is awarded
-        numTaskCompletedByWeek++;
-        xpValueByWeek += newXp;
+        int newNumTaskCompletedByWeek = numTaskCompletedByWeek + 1;
+        if (newNumTaskCompletedByWeek > MAX_INT_VALUE) {
+            return;
+        }
+        numTaskCompletedByWeek = newNumTaskCompletedByWeek;
+
+        int updatedXpValueByWeek = xpValueByWeek + newXp;
+        if (updatedXpValueByWeek > MAX_INT_VALUE) {
+            return;
+        }
+        xpValueByWeek = updatedXpValueByWeek;
     }
 
     /**


### PR DESCRIPTION
Change Log
---
If under the unlikely circumstances, the increased xp or number of tasks completed is expected to exceed 1000000000, these fields will no long be updated.